### PR TITLE
Add treesitter to installation example dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
     "OXY2DEV/markview.nvim",
     dependencies = {
         "nvim-tree/nvim-web-devicons", -- Used by the code bloxks
+        "nvim-treesitter/nvim-treesitter",
     },
 
     config = function ()
@@ -54,6 +55,7 @@ return {
     "OXY2DEV/markview.nvim",
     dependencies = {
         "nvim-tree/nvim-web-devicons", -- Used by the code bloxks
+        "nvim-treesitter/nvim-treesitter",
     },
 
     config = function ()
@@ -69,6 +71,7 @@ require("mini.deps").add({
     source = "OXY2DEV/markview.nvim",
     depends = {
         "nvim-tree/nvim-web-devicons", -- Used by the code bloxks
+        "nvim-treesitter/nvim-treesitter",
     }
 })
 ```


### PR DESCRIPTION
Add `nvim-treesitter` to plugin dependencies. This plugin does not function without treesitter, but treesitter is not in the dependencies of either installation example.