### PR TITLE
Remove hard dependency on nvim-treesitter plugin

### DIFF
--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -1,13 +1,18 @@
 local markview = require("markview");
+local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers");
+local function parser_installed(parser)
+	return (ts_available and treesitter_parsers.has_parser(parser)) or
+		(vim.treesitter.query.get(parser, "highlights"))
+end
 
 -- Check for requirements
 if vim.fn.has("nvim-0.10") == 0 then
 	vim.print("[ markview.nvim ] : Thie plugin is only available on version 0.10.0 and higher!");
 	return;
-elseif not vim.treesitter.query.get("markdown", "highlights") then
+elseif not parser_installed("markdown") then
 	vim.print("[ markview.nvim ] : Treesitter parser for 'markdown' wasn't found!");
 	return;
-elseif not vim.treesitter.query.get("markdown_inline", "highlights") then
+elseif not parser_installed("markdown_inline") then
 	vim.print("[ markview.nvim ] : Treesitter parser for 'markdown_inline' wasn't found!");
 	return;
 end

--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -1,17 +1,13 @@
 local markview = require("markview");
-local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers");
 
 -- Check for requirements
 if vim.fn.has("nvim-0.10") == 0 then
 	vim.print("[ markview.nvim ] : Thie plugin is only available on version 0.10.0 and higher!");
 	return;
-elseif ts_available == false then
-	vim.print("[ markview.nvim ] : Treesitter needs to be available to use this plugin!");
-	return;
-elseif treesitter_parsers.has_parser("markdown") == false then
+elseif not vim.treesitter.query.get("markdown", "highlights") then
 	vim.print("[ markview.nvim ] : Treesitter parser for 'markdown' wasn't found!");
 	return;
-elseif treesitter_parsers.has_parser("markdown_inline") == false then
+elseif not vim.treesitter.query.get("markdown_inline", "highlights") then
 	vim.print("[ markview.nvim ] : Treesitter parser for 'markdown_inline' wasn't found!");
 	return;
 end


### PR DESCRIPTION
Markview has a hard dependency on the nvim-treesitter plugin (ie. the plugin won't load without it). This is unnecessary because the true dependency is on the markdown and markdown_inline treesitter parsers, not on the nvim-treesitter plugin itself. The check should be changed to use the vim.treesitter functions instead to check for dependencies and not on the nvim-treesitter plugin. This allows for the use of other treesitter parser installers such as that found on rocks.nvim.

NOTE: nvim-treesitter is actually moving away from having plugins depend on it for configuration and just being purely for installing and maintaining parsers/queries (See: https://github.com/nvim-treesitter/nvim-treesitter/issues/4767)