### PR TITLE
feat: replace tbl_islist to islist

### DIFF
--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -806,7 +806,7 @@ renderer.render_block_quotes = function (buffer, content, config_table)
 		for _, callout in ipairs(config_table.callouts) do
 			if type(callout.match_string) == "string" and callout.match_string:upper() == content.callout:upper() then
 				qt_config = callout;
-			elseif vim.tbl_islist(callout.aliases) then
+			elseif vim.islist(callout.aliases) then
 				for _, alias in ipairs(callout.aliases) do
 					if type(alias) == "string" and alias:upper() == content.callout.upper() then
 						qt_config = callout;


### PR DESCRIPTION
Hi 👋

First of all, I want to say thanks for this amazing plugin, it's really improved the readability for markdown files.

This pull request replaces api `tbl_islist` which is deprecated to `islist`.

As in the readme it says minimal requirement is neovim 0.10, thus I did not make it backward compatible.

The `islist` api is in neovim 0.10 stable release, see: https://github.com/neovim/neovim/commit/d9d890562e43493c999f8a6ff2b848959686f5b6