### PR TITLE
fixed README setup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ require("markview").setup({
     images = {},
     inline_codes = {},
     list_items = {},
-    list_items = {},
     checkboxes = {},
     tables = {}
 });


### PR DESCRIPTION
There was a duplicate `list_items = {},`