### PR TITLE
Fixed UTF-8 multibyte characters causing table border to display at wrong position

### DIFF
--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -240,7 +240,7 @@ local table_header = function (buffer, content, config_table)
 			end
 
 			table.insert(virt_txt, { string.rep(tbl_conf.text[2], actual_width), set_hl(tbl_conf.hl[2]) })
-			curr_col = curr_col + vim.fn.strchars(col);
+			curr_col = curr_col + vim.fn.strlen(col);
 			curr_tbl_col = curr_tbl_col + 1;
 		end
 	end
@@ -457,7 +457,7 @@ local table_footer = function (buffer, content, config_table)
 			end
 
 			table.insert(virt_txt, { string.rep(tbl_conf.text[2], actual_width), set_hl(tbl_conf.hl[2]) })
-			curr_col = curr_col + vim.fn.strchars(col);
+			curr_col = curr_col + vim.fn.strlen(col);
 			curr_tbl_col = curr_tbl_col + 1;
 		end
 	end
@@ -549,7 +549,7 @@ local table_content = function (buffer, content, config_table, r_num)
 				end
 			end
 
-			curr_col = curr_col + vim.fn.strchars(col);
+			curr_col = curr_col + vim.fn.strlen(col);
 			curr_tbl_col = curr_tbl_col + 1;
 		end
 	end


### PR DESCRIPTION
When rendering a table, markview would increment the current column based on the `vim.fn.strchars()` function, which would return the number of characters in the column. 

However, the nvim api appears to use byte number to indicate the column, rather than UTF-8 character count. Thus, when multibyte characters were present, the border would render in the wrong position. 

![image](https://github.com/OXY2DEV/markview.nvim/assets/106889516/b26630b3-7d56-4160-806a-673d6eb60083)


This fix uses the `vim.fn.strlen()` function as an alternative, which counts the number of bytes in the column, rather than characters. 


![image](https://github.com/OXY2DEV/markview.nvim/assets/106889516/cad79999-aa89-41f3-a745-a65c7d6cebe6)
