### PR TITLE
Add on_enable and on_disable function hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ require("markview").setup({
     -- Returns the concealcursor to the global value when changing modes
     restore_concealcursor = false,
 
+    -- Is called after concealment starts
+    on_enable = function() end,
+    -- Is called after concealment is cleared
+    on_disable = function() end,
+
     headings = {},
     code_blocks = {},
     block_quotes = {},
@@ -131,7 +136,6 @@ require("markview").setup({
     hyperlinks = {},
     images = {},
     inline_codes = {},
-    list_items = {},
     list_items = {},
     checkboxes = {},
     tables = {}

--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -68,6 +68,7 @@ vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
 		for _, window in ipairs(windows) do
 			markview.keymaps.init(buffer, window, parsed_content, markview.configuration);
 		end
+        markview.configuration.on_enable()
 	end
 });
 
@@ -102,6 +103,7 @@ vim.api.nvim_create_autocmd({ "ModeChanged", "TextChanged" }, {
 
 				markview.keymaps.init(buffer, window, parsed_content, markview.configuration);
 			end
+            markview.configuration.on_enable()
 		else
 			for _, window in ipairs(windows) do
 				if markview.configuration.restore_conceallevel == true then
@@ -116,6 +118,7 @@ vim.api.nvim_create_autocmd({ "ModeChanged", "TextChanged" }, {
 			end
 
 			markview.renderer.clear(buffer);
+            markview.configuration.on_disable()
 		end
 	end
 });

--- a/lua/definitions.lua
+++ b/lua/definitions.lua
@@ -68,6 +68,11 @@
 --- When true, revert the value of concealcursor to global value
 ---@field restore_concealcursor boolean?
 ---
+--- Called after enabling concealment
+---@field on_enable function
+---
+--- Called after disabling concealment
+---@field on_disable function
 --- Table for heading configuration
 ---@field headings markview.render_config.headings
 ---

--- a/lua/markview.lua
+++ b/lua/markview.lua
@@ -56,6 +56,9 @@ markview.configuration = {
 	restore_conceallevel = true,
 	restore_concealcursor = false,
 
+    on_enable = function() end,
+    on_disable = function() end,
+
 	highlight_groups = {
 		{
 			group_name = "col_1",
@@ -616,6 +619,7 @@ markview.commands = {
 			markview.renderer.clear(buf);
 			markview.renderer.render(buf, parsed_content, markview.configuration)
 		end
+        markview.configuration.on_enable()
 	end,
 	disableAll = function ()
 		if markview.configuration.restore_conceallevel == true then
@@ -672,6 +676,7 @@ markview.commands = {
 
 		markview.renderer.clear(buffer);
 		markview.renderer.render(buffer, parsed_content, markview.configuration)
+        markview.configuration.on_enable()
 	end,
 
 	disable = function (buf)
@@ -697,6 +702,7 @@ markview.commands = {
 
 		markview.renderer.clear(buffer);
 		markview.state.buf_states[buffer] = false;
+        markview.configuration.on_disable()
 	end
 }
 


### PR DESCRIPTION
Hi, thanks for the great plugin.
I want to add on_enable and on_disable events to override default behavior. 
Instead of needing to add multiple configuration options for things such as conceal levels, scroll, spell, etc, it might be better to create these hooks that allow for the user to customize **just** the behavior of neovim.

For example, using the obsidian.nvim plugin's ui feature results in not being able to see the actual link

https://github.com/OXY2DEV/markview.nvim/assets/43306454/36750c95-c07e-4567-822d-588fd41989d5

Using hooks, and the function, its possible to change the behavior of neovim based on the rendering mode:
```lua
require("markview").setup({
  on_enable = function() vim.o.concealcursor = "" end
})
```

https://github.com/OXY2DEV/markview.nvim/assets/43306454/894705b6-588b-4cc5-bd6c-f7bdb28677dd


