### PR TITLE
fix: Use `tbl_deep_extend` when creating config instead of `tbl_extend`

### DIFF
--- a/lua/markview.lua
+++ b/lua/markview.lua
@@ -821,7 +821,7 @@ end, {
 markview.setup = function (user_config)
 	---@type markview.config
 	-- Merged configuration tables
-	markview.configuration = vim.tbl_extend("keep", user_config or {}, markview.configuration);
+	markview.configuration = vim.tbl_deep_extend("keep", user_config or {}, markview.configuration);
 
 	if vim.islist(markview.configuration.highlight_groups) then
 		markview.add_hls(markview.configuration.highlight_groups);


### PR DESCRIPTION
Hi! I had issues configuring this plugin and realized the reason why. I was trying to enable virtual lines like this:

```lua
{
  'OXY2DEV/markview.nvim',
  ft = 'markdown',
  dependencies = {
    'nvim-treesitter/nvim-treesitter',
    'nvim-tree/nvim-web-devicons'
  },
  opts = {
    tables = {
      use_virt_lines = true,
    }
  }
}
```

however, markview started throwing a bunch of errors on startup because a bunch of `tables` options were suddenly missing. The problem with using `tbl_extend` instead of `tbl_deep_extend` is that the entire `tables` table in my case got overriden. Using `tbl_deep_extend` fixes this since it preserves the entire default `tables` configuration, and (in my case) only alters the `tables.use_virt_lines` field.
