### PR TITLE
Fix bug when removing `nvim-web-devicons` dependency.

### DIFF
--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -1,6 +1,4 @@
 local renderer = {};
-local devicons = require("nvim-web-devicons");
-
 local entites = require("markview.entites");
 local languages = require("markview.languages");
 
@@ -955,6 +953,7 @@ renderer.render_code_blocks = function (buffer, content, config_table)
 			})
 		end
 	elseif config_table.style == "language" then
+		local devicons = require("nvim-web-devicons");
 		local language = content.language;
 		local icon, hl = devicons.get_icon(nil, language, { default = true });
 		local block_length = content.largest_line;


### PR DESCRIPTION
When trying to avoid using `nvim-web-devicons` icons, I encountered an error message saying 'Error loading `markview` module'. After inspecting the plugin's source code, I discovered that the issue was due to the `require('nvim-web-devicons')` line added at the beginning of the `renderer.lua` file. To fix it, I moved that line below the conditional `elseif config_table.style == "language" then` and it worked. Now I can remove the `nvim-web-devicons` dependency without issues.
