### PR TITLE
fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ require("markview").setup({
     callbacks = {
         on_enable = function (_, win)
             vim.wo[win].conceallevel = 2;
-            vim.wo[win].conecalcursor = "c";
+            vim.wo[win].cocealcursor = "c";
         end
     }
 })

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ require("markview").setup({
     callbacks = {
         on_enable = function (_, win)
             vim.wo[win].conceallevel = 2;
-            vim.wo[win].cocealcursor = "c";
+            vim.wo[win].concealcursor = "c";
         end
     }
 })


### PR DESCRIPTION
```gitdiff
@@ -166,7 +167,7 @@ require("markview").setup({
     callbacks = {
         on_enable = function (_, win)
             vim.wo[win].conceallevel = 2;
-            vim.wo[win].conecalcursor = "c";
+            vim.wo[win].concealcursor = "c";
         end
     }
 })
```