### PR TITLE
feat: entire entity config as function

### DIFF
--- a/lua/definitions.lua
+++ b/lua/definitions.lua
@@ -198,7 +198,7 @@
 ---@field corner_left_hl string?
 ---
 --- Used bu the "label" style to add text after the right padding
----@field corner_right string?
+---@field corner_right (string | function)?
 ---
 --- Highlight group for the right corner
 ---@field corner_right_hl string?

--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -850,20 +850,25 @@ renderer.render_headings = function (buffer, content, config)
 		return;
 	end
 
-	---@type markview.render_config.headings.h
-	local conf = config["heading_" .. content.level] or {};
+	local conf = {};
+	local heading_n = "heading_" .. content.level
+
+	if type(config[heading_n]) == "function" then
+		local success, result = pcall(config[heading_n], buffer, content)
+		if success then
+			conf = result
+		end
+	elseif type(config[heading_n]) == "table" then
+		conf = config[heading_n];
+	end
+
+	print(vim.inspect(conf))
+
 	local shift = config.shift_width or vim.bo[buffer].shiftwidth;
 
 	-- Do not proceed if config doesn't exist for a heading
 	if not conf then
 		return;
-	end
-
-	local corner_right = ""
-	if type(conf.corner_right) == "function" and pcall(conf.corner_right --[[@as function]], buffer, content) then
-		corner_right = conf.corner_right(buffer, content);
-	elseif type(conf.corner_right) == "string" then
-		corner_right = conf.corner_right --[[@as string]];
 	end
 
 	if conf.style == "simple" then
@@ -896,7 +901,7 @@ renderer.render_headings = function (buffer, content, config)
 					content.title,
 
 					conf.padding_right or "",
-					corner_right,
+					conf.corner_right or "",
 				}));
 
 				spaces = math.floor((w - t) / 2);
@@ -914,7 +919,7 @@ renderer.render_headings = function (buffer, content, config)
 					content.title,
 
 					conf.padding_right or "",
-					corner_right,
+					conf.corner_right or "",
 				}));
 
 				spaces = w - t;
@@ -947,7 +952,7 @@ renderer.render_headings = function (buffer, content, config)
 			virt_text_pos = "overlay",
 			virt_text = {
 				{ conf.padding_right or "", set_hl(conf.padding_right_hl) or set_hl(conf.hl) },
-				{ corner_right, set_hl(conf.corner_right_hl) or set_hl(conf.hl) }
+				{ conf.corner_right or "", set_hl(conf.corner_right_hl) or set_hl(conf.hl) }
 			},
 
 			hl_mode = "combine"

--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -859,6 +859,13 @@ renderer.render_headings = function (buffer, content, config)
 		return;
 	end
 
+	local corner_right = ""
+	if type(conf.corner_right) == "function" and pcall(conf.corner_right --[[@as function]], buffer, content) then
+		corner_right = conf.corner_right(buffer, content);
+	elseif type(conf.corner_right) == "string" then
+		corner_right = conf.corner_right --[[@as string]];
+	end
+
 	if conf.style == "simple" then
 		-- Adds a simple background
 		vim.api.nvim_buf_set_extmark(buffer, renderer.namespace, content.row_start, content.col_start, {
@@ -889,7 +896,7 @@ renderer.render_headings = function (buffer, content, config)
 					content.title,
 
 					conf.padding_right or "",
-					conf.corner_right or "",
+					corner_right,
 				}));
 
 				spaces = math.floor((w - t) / 2);
@@ -907,7 +914,7 @@ renderer.render_headings = function (buffer, content, config)
 					content.title,
 
 					conf.padding_right or "",
-					conf.corner_right or "",
+					corner_right,
 				}));
 
 				spaces = w - t;
@@ -940,7 +947,7 @@ renderer.render_headings = function (buffer, content, config)
 			virt_text_pos = "overlay",
 			virt_text = {
 				{ conf.padding_right or "", set_hl(conf.padding_right_hl) or set_hl(conf.hl) },
-				{ conf.corner_right or "", set_hl(conf.corner_right_hl) or set_hl(conf.hl) }
+				{ corner_right, set_hl(conf.corner_right_hl) or set_hl(conf.hl) }
 			},
 
 			hl_mode = "combine"


### PR DESCRIPTION
## What

`corner_right` can also be a function.

```lua
heading_2 = {
  corner_right = function(buffer, content)

  end,
},
```

## Why

`corner_right` can only be `string` or `nil`. It limits user ability to tweak headers looks.

In my case, I want to make all rendered elements respect my `textwidth` option. Header's `corner_right` content should be calculated for each header in order to achieve that.

With this PR I do it like this:

```lua
heading_2 = {
  style = "label",
  sign = "",
  corner_right = function(buffer, content)
    local textwidth = vim.api.nvim_get_option_value("textwidth", { buf = buffer })

    return string.rep(" ", textwidth - #content.line - 1);
  end,
},
```

Result looks like this:

![Screenshot 2024-09-05 at 08 23 34](https://github.com/user-attachments/assets/e1e7c592-b13d-4cf8-b046-c98e87fc1b18)

## Questions

1. Maybe options like `corner_left`, `padding_left`, `padding_right`, `shift_char` should be functions too?
2. What do you think about respecting `textwidth` on plugin level? Maybe it's a good idea to implement it as global or per element setting.