### PR TITLE
fix: Links/Images with list characters are overindented in tables

### DIFF
--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -60,11 +60,16 @@ local set_hl = function (hl)
 	end
 end
 
+-- NOTE: Table cells with list chars in a link or image are overindented
+local sub_indent_chars = function(text)
+	return text:gsub("[-+*]", " ")
+end
+
 local display_width = function (text, config)
 	local d_width = vim.fn.strdisplaywidth(text);
 	local inl_conf = config.inline_codes;
 
-	local final_string = text;
+	local final_string = sub_indent_chars(text);
 
 	for escaped_char in final_string:gmatch("\\([\\%.%*%_%{%}%[%]%<%>%(%)%#%+%-%`%!%|%$])") do
 		if config.escaped ~= nil and config.escaped.enable ~= false then


### PR DESCRIPTION
## Description

Hi, I've noticed that table cells containing link or image with list characters (`*`, `-`, `+`) break the table layout.

Consider this markup:

```md
| Icon                     | Description |
|--------------------------|-------------|
| ![Item 1](item1.svg)     | Desc 1      |
| ![Item-2](item2.svg)     | Desc 2      |
| ![Item 3](item-3.svg)    | Desc 3      |
| ![Item-4](item-4.svg)    | Desc 4      |
| ![Item*5](item5.svg)     | Desc 5      |
| ![Item+6](item6.svg)     | Desc 6      |
| [Item+7](item7.svg)      | Desc 7      |
| 1. ![Item8](item8.svg)   | Desc 8      |
| 1) ![Item9](item9.svg)   | Desc 9      |
| 1. Item 10               | Desc 10     |
| 1) Item 11               | Desc 11     |
```

You would assume that this table is well formatted, but the result is not as expected:

![image](https://github.com/user-attachments/assets/684dde3b-31a6-4c87-a631-9a20da6697bc)

Is seems that unordered lists break the layout by overindenting the cell contents:

* The character can be in the alt text or in the image path, it will have the same effect.  
* A cell containing two of these characters will be overindented twice as much, and so on...

## Changes

This PR address the problem by stripping the list leading characters from the text when renderer gets the width of a field.

I haven't noticed any issue with ordered lists (`1.`, `1)`), so I left it alone.

Result:

![image](https://github.com/user-attachments/assets/4b590882-57c7-4722-9d5a-4e65627799a5)
