### PR TITLE
Fix: Unsupported marker content in checkboxes

### DIFF
--- a/lua/markview/parser.lua
+++ b/lua/markview/parser.lua
@@ -655,8 +655,15 @@ parser.md_inline = function (buffer, TStree, from, to)
 						local start_line = extmark.list_lines[1] or "";
 						local atStart = start_line:match("[+%-*]%s+(%[%" .. marker .. "%])%s+");
 
-						local chk_start, _ = start_line:find("%[%" .. marker .. "%]");
+						local success, result = pcall(function()
+							return start_line:find("%[%" .. marker .. "%]")
+						end)
 
+						if not success then
+							print("Error: The content inside [ ] brackets contains an unsupported marker: '" .. marker .. "'. This is not supported in checkboxes.")
+						else
+							chk_start = result
+						end
 						if not atStart or not chk_start or chk_start - 1 ~= col_start then
 							goto invalid;
 						end


### PR DESCRIPTION
This PR addresses an issue where unsupported markers inside [ ] brackets in checkboxes cause errors during rendering, which prevents the Markdown from being displayed correctly.

### Problem Details:

When opening a Markdown file containing unsupported checkbox content, an error occurs, leading to a failure in rendering the Markdown. The error message observed is:

> Error executing Lua callback: ...al/share/nvim/lazy/markview.nvim/Lua/markview/parser.Lua:658: invalid capture index
Stack traceback:
> c: in function 'find'


This fix is crucial because the error prevents proper rendering of Markdown files containing these specific checkbox markers. By addressing this issue, the plugin will provide a more robust and error-free experience when working with checkboxes, ensuring that users can render their Markdown content correctly without interruption.

I would like to thank the author for this great plugin. I really enjoy using it, and I appreciate all the hard work that has gone into making it so helpful!