### PR TITLE
fix: Unload markview plugin if buffer is invalid

### DIFF
--- a/plugin/markview.lua
+++ b/plugin/markview.lua
@@ -120,6 +120,14 @@ local redraw_autocmd = function (augroup, buffer)
 				end
 
 				--- Incorrect file type
+				if not vim.api.nvim_buf_is_valid(buffer) then
+					markview.unload();
+					vim.api.nvim_del_autocmd(r_autocmd);
+
+					return;
+				end
+
+				--- Incorrect file type
 				if not vim.list_contains(markview.configuration.filetypes or { "markdown" }, vim.bo[buffer].filetype) then
 					markview.unload();
 					vim.api.nvim_del_autocmd(r_autocmd);


### PR DESCRIPTION
 - Added a check to unload the markview plugin and delete the autocmd if the buffer is not valid.
 - This prevents potential errors when the buffer is invalid and ensures the plugin behaves correctly.