### PR TITLE
fix: allow single space between > and callout bracket

### DIFF
--- a/lua/markview/parser.lua
+++ b/lua/markview/parser.lua
@@ -842,13 +842,13 @@ parser.md_inline = function (buffer, TStree, from, to)
 					col_start = col_start,
 					col_end = col_end,
 				});
-			elseif before:match("%>$") then
+			elseif before:match("%> ?$") then
 				local title = string.match(line or "", "%b[](.*)$")
 
 				for _, extmark in ipairs(parser.parsed_content) do
 					if extmark.type == "block_quote"
 						and extmark.row_start == row_start
-						and extmark.col_start == col_start - 1
+						and (extmark.col_start == col_start - before:match("%> ?$"):len())
 					then
 						extmark.callout = string.match(capture_text, "%[!([^%]]+)%]");
 						extmark.title = title;

--- a/lua/markview/parser.lua
+++ b/lua/markview/parser.lua
@@ -848,7 +848,7 @@ parser.md_inline = function (buffer, TStree, from, to)
 				for _, extmark in ipairs(parser.parsed_content) do
 					if extmark.type == "block_quote"
 						and extmark.row_start == row_start
-						and (extmark.col_start == col_start - before:match("%> ?$"):len())
+						and extmark.col_start == col_start - before:match("%> ?$"):len()
 					then
 						extmark.callout = string.match(capture_text, "%[!([^%]]+)%]");
 						extmark.title = title;


### PR DESCRIPTION
Hi, I noticed callouts aren't rendered properly in all of my notes that I had taken in Obsidian.
I realized this is because Obsidian, GitHub and likely more allow a space between the `>` and the start of the callout, i.e.

```markdown
> [!NOTE]
> *body of note*
```

I've made a very small fix that allows for an optional space between `>` and `[` on the starting line of the callout.