### PR TITLE
Ensure buffer is still loaded in debounced render timer

### DIFF
--- a/plugin/markview.lua
+++ b/plugin/markview.lua
@@ -120,6 +120,10 @@ local redraw_autocmd = function (augroup, buffer, validate)
 					return;
 				end
 
+        			if not vim.api.nvim_buf_is_loaded(buffer) then
+          				return;
+        			end
+
 				if validate == false then
 					goto noValidation;
 				end


### PR DESCRIPTION
I have custom functions to switch between projects/sessions.
In these I wipe out buffers not belonging to the newly loaded session. This generates an error in markview.nvim.
This change prevents this error.