### PR TITLE
render error

### DIFF
--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -872,7 +872,7 @@ markdown.code_block = function (buffer, item)
 			end
 		elseif config.language_direction == "right" then
 			vim.api.nvim_buf_set_extmark(buffer, markdown.ns("code_blocks"), range.row_start, range.col_start, {
-				end_col = range.col_start + (range.info_start or range.lang_end),
+				end_col = range.col_start + (range.info_start or range.lang_end or 0),
 				conceal = "",
 				undo_restore = false, invalidate = true,
 


### PR DESCRIPTION
while rendering https://gist.github.com/Hashino/6d54ba515c7407ab9dd780d0326997da got the error:

   Error  Error executing vim.schedule lua callback: ...markview.nvim/lua/markview/renderers/markdown_inline.lua:238: Invalid 'end_col': out of range

this commit fixes it