### PR TITLE
Only open link and not word under cursor with MarkOpen

### DIFF
--- a/lua/markview/keymaps.lua
+++ b/lua/markview/keymaps.lua
@@ -31,7 +31,7 @@ keymaps.create_command = function (buffer)
 
 			if cmd then
 				cmd:wait();
-				break;
+				return;
 			end
 
 		    ::continue::


### PR DESCRIPTION
Hey there, thanks for the awesome plugin, it looks absolutely stunning.
There's one thing that annoyed me a little though, that being that `MarkOpen` opens the word under the cursor even if a proper link is found and opened, resulting in two browser tabs being opened. This small change only opens the link under the cursor, but still falls back to opening the word when no link is found.