### PR TITLE
Move parser_installed() to a utils function.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lua]
+max_line_length = 160
+indent_style = tab
+quote_style = double

--- a/lua/markview/health.lua
+++ b/lua/markview/health.lua
@@ -1,19 +1,12 @@
 local health = {};
 
-local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers");
+local utils = require("markview.utils")
 
-local devicons_loaded = pcall(require, "nvim-web-devicons");
-local mini_loaded = pcall(require, "mini.icons");
+health.check = function()
+	local ver = vim.version()
 
---- Checks if a parser is available or not
----@param parser_name string
----@return boolean
-local function parser_installed(parser_name)
-	return (ts_available and treesitter_parsers.has_parser(parser_name)) or pcall(vim.treesitter.query.get, parser_name, "highlights")
-end
-
-health.check = function ()
-	local ver = vim.version();
+	local devicons_loaded = pcall(require, "nvim-web-devicons")
+	local mini_loaded = pcall(require, "mini.icons")
 
 	vim.health.start("Checking essentials:")
 
@@ -25,6 +18,8 @@ health.check = function ()
 		vim.health.error("Unsupported neovim version. Minimum requirement `0.10.1`, found: " .. string.format("`%d.%d.%d`", ver.major, ver.minor, ver.patch));
 	end
 
+	local ts_available, _ = pcall(require, "nvim-treesitter.parsers")
+
 	if ts_available then
 		vim.health.ok("`nvim-treesitter/nvim-treesitter` found!")
 	else
@@ -34,7 +29,7 @@ health.check = function ()
 	vim.health.start("Checking parsers:")
 
 	for _, parser in ipairs({ "markdown", "markdown_inline", "html", "latex" }) do
-		if parser_installed(parser) then
+		if utils.parser_installed(parser) then
 			vim.health.ok("`" .. parser .. "` " .. "was found!");
 		else
 			vim.health.warn("`" .. parser .. "` " .. "wasn't found.");

--- a/lua/markview/parser.lua
+++ b/lua/markview/parser.lua
@@ -1,14 +1,6 @@
 local parser = {};
 local lang = require("markview.languages")
-
-local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers");
-
---- Checks if a parser is available or not
----@param parser_name string
----@return boolean
-local function parser_installed(parser_name)
-	return (ts_available and treesitter_parsers.has_parser(parser_name)) or pcall(vim.treesitter.query.get, parser_name, "highlights")
-end
+local utils = require("markview.utils")
 
 ---@type markview.configuration | {}
 parser.cached_conf = {};
@@ -280,7 +272,7 @@ parser.parsed_content = {};
 ---@param buffer number
 ---@param TStree any
 parser.md = function (buffer, TStree, from, to)
-	if not parser_installed("markdown") then
+	if not utils.parser_installed("markdown") then
 		return;
 	end
 
@@ -726,7 +718,7 @@ end
 ---@param buffer number
 ---@param TStree any
 parser.md_inline = function (buffer, TStree, from, to)
-	if not parser_installed("markdown_inline") then
+	if not utils.parser_installed("markdown_inline") then
 		return;
 	end
 
@@ -753,7 +745,7 @@ parser.md_inline = function (buffer, TStree, from, to)
 			(inline_link)
 			(full_reference_link)
 		] @hyperlink)
-			
+
 		((email_autolink) @email)
 		((image) @image)
 
@@ -965,7 +957,7 @@ parser.md_inline = function (buffer, TStree, from, to)
 end
 
 parser.html = function (buffer, TStree, from, to)
-	if not parser_installed("html") then
+	if not utils.parser_installed("html") then
 		return;
 	end
 
@@ -983,7 +975,7 @@ parser.html = function (buffer, TStree, from, to)
 			local root = TStree:root();
 			local root_r_start, _, _, _ = root:range();
 
-			if root_r_start >= tbl.row_start and root_r_start <= tbl.row_end then	
+			if root_r_start >= tbl.row_start and root_r_start <= tbl.row_end then
 				return;
 			end
 
@@ -1035,7 +1027,7 @@ parser.html = function (buffer, TStree, from, to)
 end
 
 parser.latex = function (buffer, TStree, from, to)
-	if not parser_installed("latex") then
+	if not utils.parser_installed("latex") then
 		return;
 	end
 

--- a/lua/markview/renderer.lua
+++ b/lua/markview/renderer.lua
@@ -2,13 +2,6 @@ local renderer = {};
 local devicons_loaded, devicons = pcall(require, "nvim-web-devicons");
 local mini_loaded, MiniIcons = pcall(require, "mini.icons");
 
---- Checks if a parser is available or not
----@param parser_name string
----@return boolean
-local function parser_installed(parser_name)
-	return (ts_available and treesitter_parsers.has_parser(parser_name)) or pcall(vim.treesitter.query.get, parser_name, "highlights")
-end
-
 local utils = require("markview.utils");
 local languages = require("markview.languages");
 local latex_renderer = require("markview.latex_renderer");
@@ -211,7 +204,7 @@ local display_width = function (text, config)
 	local html_conf = config.html;
 
 	--- Without inline parser inline these syntaxes shouldn't occur
-	if not parser_installed("markdown_inline") then
+	if not utils.parser_installed("markdown_inline") then
 		goto noMdInline;
 	end
 
@@ -475,7 +468,7 @@ local display_width = function (text, config)
 	::noMdInline::
 
 	--- Without HTML parser these syntaxes shouldn't occur
-	if not parser_installed("html") then
+	if not utils.parser_installed("html") then
 		return d_width, vim.fn.strdisplaywidth(text), final_string;
 	end
 
@@ -657,7 +650,7 @@ local table_header = function (buffer, content, config_table)
 			-- Extracted width of separator
 			local tbl_col_width = math.max(content.col_widths[curr_tbl_col], tbl_conf.col_min_width or 0);
 
-			-- The column number of headers must match the 
+			-- The column number of headers must match the
 			-- column number of separators
 			--
 			-- No need to add unnecessary condition
@@ -1461,7 +1454,7 @@ renderer.render_code_blocks = function (buffer, content, config_table)
 		end
 
 		-- The text on the final line
-		-- We need to get the tail section to see if it contains ``` 
+		-- We need to get the tail section to see if it contains ```
 		local block_end_line = vim.api.nvim_buf_get_lines(buffer, content.row_end - 1, content.row_end, false)[1];
 
 		vim.api.nvim_buf_set_extmark(buffer, renderer.namespace, content.row_end - 1, vim.fn.strchars(block_end_line or ""), {
@@ -2155,7 +2148,7 @@ end
 
 --- Footnote renderer
 ---@param buffer integer
----@param content table 
+---@param content table
 ---@param user_config markview.conf.footnotes
 renderer.render_footnotes = function (buffer, content, user_config)
 	if not user_config or user_config.enable == false then

--- a/lua/markview/utils.lua
+++ b/lua/markview/utils.lua
@@ -56,6 +56,14 @@ utils.get_cursor_range = function (buffer, window)
 	local lines = vim.api.nvim_buf_line_count(buffer);
 
 	return math.max(0, cursor[1] - 1), math.min(lines, cursor[1]);
+--- Checks if a parser is available or not
+---@param parser_name string
+---@return boolean
+utils.parser_installed = function(parser_name)
+    local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers")
+
+    -- Use pcall as in nvim-treesitter's main branch, '.parsers' is a table, and has no 'has_parser' function.
+    return (ts_available and pcall(treesitter_parsers, has_parser, parser_name)) or pcall(vim.treesitter.query.get, parser_name, "highlights")
 end
 
 return utils;

--- a/lua/markview/utils.lua
+++ b/lua/markview/utils.lua
@@ -56,6 +56,8 @@ utils.get_cursor_range = function (buffer, window)
 	local lines = vim.api.nvim_buf_line_count(buffer);
 
 	return math.max(0, cursor[1] - 1), math.min(lines, cursor[1]);
+end
+
 --- Checks if a parser is available or not
 ---@param parser_name string
 ---@return boolean


### PR DESCRIPTION
Update to handle nvim-treesitter's main branch

Move icon requirements into health function.

Add a `.editorconfig` file to keep the same style as you currently have.