### PR TITLE
fix(devicons): properly fetch devicons by filetype

### DIFF
--- a/lua/markview/filetypes.lua
+++ b/lua/markview/filetypes.lua
@@ -731,9 +731,8 @@ fts.get = function (ft)
 	local conf = {};
 
 	if provider_name == "devicons" and pcall(require, "nvim-web-devicons") then
-		conf.icon, conf.icon_hl = require("nvim-web-devicons").get_icon(
-			string.format("example.%s", ft),
-			nil,
+		conf.icon, conf.icon_hl = require("nvim-web-devicons").get_icon_by_filetype(
+			ft,
 			{ default = true }
 		);
 


### PR DESCRIPTION
This PR fixes devicons retrieval by using filetype instead filename (more chances to match and devicons maintain a filetype aliases map)

## Before  
![image](https://github.com/user-attachments/assets/df9109c0-f7c4-4d9b-a508-cdf06af55938)

## After
![image](https://github.com/user-attachments/assets/adf39464-9ae9-4215-b40b-84ed64656531)
