### PR TITLE
Chore(filetypes.lua): Added back no provider option

### DIFF
--- a/lua/markview/filetypes.lua
+++ b/lua/markview/filetypes.lua
@@ -752,6 +752,12 @@ fts.get = function (ft)
 		conf.sign = conf.icon;
 		conf.sign_hl = conf.icon_hl;
 		conf.border_hl = conf.icon_hl;
+	elseif provider_name == '' then
+		local no_icon = ''
+		conf.icon = no_icon
+		conf.icon_hl = no_icon
+		conf.sign = no_icon
+		conf.hl = no_icon
 	else
 		conf = fts.styles[_ft] or fts.styles[ft] or fts.styles["default"];
 	end


### PR DESCRIPTION
In v24 he wad the option to set (now deprecated) `icons` to `''` to ignore icons; adding back after refactor.

Hi, this is one of my first real PRs, I noted that we did not get the `icons = ''` option with v25 (thanks a lot) to disable icons in `code blocks` / `sign` column , tested quickly, seems to work fine.

<img width="1440" alt="Screenshot 2025-01-25 at 20 22 18" src="https://github.com/user-attachments/assets/63a22a44-e998-442d-964e-0186188dbfcf" />
