### PR TITLE
fix(presets): Fix icon highlight for marker preset

### DIFF
--- a/lua/markview/presets.lua
+++ b/lua/markview/presets.lua
@@ -484,7 +484,7 @@ presets.headings = {
 		heading_6 = {
 			style = "icon",
 
-			icon = "█ ", icon_hl = "MarkviewHeading5Sign",
+			icon = "█ ", icon_hl = "MarkviewHeading6Sign",
 			hl = "MarkviewHeading6",
 		}
 		---_


### PR DESCRIPTION
The icon highlight for heading 6 of the marker preset is incorrect. It's set to the highlight for heading 5 instead of 6.

| `main` | After fix |
| ------------- | ------------- |
| ![marker_h6_original](https://github.com/user-attachments/assets/a0134e57-245f-4739-b5e5-9a7de6c2787e) | ![marker_h6_fix](https://github.com/user-attachments/assets/5a851a66-5875-43e0-9df8-ba95972eed7a) |