### PR TITLE
fix(blink): use add_source_provider due to deprecation

### DIFF
--- a/plugin/markview.lua
+++ b/plugin/markview.lua
@@ -41,7 +41,7 @@ if vim.g.markview_blink_loaded == false and blink ~= nil then
 		ignore_enable = true
 	});
 
-	pcall(blink.add_provider, "markview", {
+	pcall(blink.add_source_provider, "markview", {
 		name = "markview",
 		module = "blink-markview",
 


### PR DESCRIPTION
add_provider has been deprecated and will be removed in version 1.0.0 of blink.cmp.  Update to use the new function.