### PR TITLE
fix(renderer_markdown): apply `scope_hl` when concealing is disabled

### DIFF
--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -1981,12 +1981,14 @@ markdown.list_item = function (buffer, item)
 
 	local checkbox = get_state(item.checkbox);
 
-	if checkbox and config.conceal_on_checkboxes == true then
-		vim.api.nvim_buf_set_extmark(buffer, markdown.ns, range.row_start, range.col_start + item.indent, {
-			undo_restore = false, invalidate = true,
-			end_col = range.col_start + (item.indent + #item.marker + 1),
-			conceal = ""
-		});
+	if checkbox then
+    if config.conceal_on_checkboxes == true then
+      vim.api.nvim_buf_set_extmark(buffer, markdown.ns, range.row_start, range.col_start + item.indent, {
+        undo_restore = false, invalidate = true,
+        end_col = range.col_start + (item.indent + #item.marker + 1),
+        conceal = ""
+      });
+    end
 
 		if not checkbox.scope_hl then
 			goto exit;


### PR DESCRIPTION
## Description

When using a `scope_hl` in `markdown_inline.checkboxes`, it was previously ignored when concealing was also disabled with `conceal_on_checkboxes = false` in `markdown.list_items`.

The concealing only applies to the list bullets/numbers, so we can still apply the `scope_hl` to the text of the list item.

(also wondering if concealing should be disabled by default for numbered lists, as the numbers seem kinda important :grinning:)

## Example configuration

```lua
opts = {
  markdown = {
    marker_dot = { conceal_on_checkboxes = false },
    marker_parenthesis = { conceal_on_checkboxes = false },
  },

  markdown_inline = {
    checkboxes = {
      checked = { scope_hl = 'MarkviewCheckboxStriked' },
    },
  },
}
```

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2a3be004-c030-49ec-ace0-acf60d223f1d) | ![image](https://github.com/user-attachments/assets/6858cfb4-d325-431a-90c0-fe2b78277ed8) | 

Markdown:

```markdown
1. [ ] one
2. [x] two

- [ ] one
- [x] two
```