### PR TITLE
Fix bad interaction between markview and codecompanion.

### DIFF
--- a/lua/cmp-markview.lua
+++ b/lua/cmp-markview.lua
@@ -101,11 +101,10 @@ function source:complete(params, callback)
 			end
 		end
 		---_
-	else
-		return;
 	end
 
-	callback(comp);
+    -- callback must /always/ be called.
+	return callback(comp)
 end
 
 return source


### PR DESCRIPTION
Completion mechanism didn't set correct completion sources therefore messed up list of sources for preview buffers - cmp.get_config() needs to be called in a context with the filetype set.