### PR TITLE
feat(core): ts compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,11 +341,21 @@ Plug "OXY2DEV/markview.nvim"
 ### 💤 Lazy.nvim
 
 >[!WARNING]
-> Do *not* lazy load this plugin as it is already lazy-loaded.
->
-> Lazy-loading will cause **more time** for the previews to load when starting Neovim.
+> Do *not* lazy load this plugin as it is already lazy-loaded. Lazy-loading may cause **more time** for the previews to load when starting Neovim!
 
 The plugin should be loaded *after* your colorscheme to ensure the correct highlight groups are used.
+
+>[!IMPORTANT]
+> In case you are experiencing **syntax issues**(e.g. code block markers being hidden), You can use this to load `markview.nvim` first by adding it as a dependency of `nvim-treesitter`,
+>
+> ```lua
+> {
+>     "nvim-treesitter/nvim-treesitter",
+>     dependencies = { "OXY2DEV/markview.nvim" },
+>
+>     -- ... All other options.
+> },
+> ```
 
 ```lua
 -- For `plugins/markview.lua` users.

--- a/doc/markview.nvim-config.txt
+++ b/doc/markview.nvim-config.txt
@@ -212,8 +212,7 @@ Almost all the inline elements are configured the same way,
 enable ~
 
 ▌ 🧩 Important
-
-  This option is only available if it’s in `markview.<language>.<option>`!
+▌ This option is only available if it’s in `markview.<language>.<option>`!
 
   • type: `boolean`
 

--- a/doc/markview.nvim-experimental.txt
+++ b/doc/markview.nvim-experimental.txt
@@ -44,6 +44,28 @@ here,
 <
 
 ------------------------------------------------------------------------------
+check_rtp
+
+  • type: `boolean`
+    default: `true`
+
+Checks the `runtimepath` to see if `nvim-treesitter` is getting loaded before
+`markview.nvim`. If it's being loaded `markview.nvim` will be added before
+`nvim-treesitter` and an error message will be shown.
+
+▌ 🧩 Important
+▌ This assumes the directory/folder name matches the plugin name!
+
+------------------------------------------------------------------------------
+check_rtp_message
+
+  • type: `boolean`
+    default: `true`
+
+Whether to show the error message when `nvim-treesitter` gets loaded before
+`markview.nvim`.
+
+------------------------------------------------------------------------------
 date_formats
 
   • type: `string[]`

--- a/lua/definitions/experimental.lua
+++ b/lua/definitions/experimental.lua
@@ -3,6 +3,9 @@
 --- Experimental options.
 ---@class markview.config.experimental
 ---
+---@field check_rtp boolean Whether to scan the `runtimepath` for errors & potentially fixing them.
+---@field check_rtp_message boolean Whether to shoe message if `nvim-treesitter` gets loaded before `markview.nvim`.
+---
 ---@field date_formats string[] List of lua patterns for detecting date in YAML.
 ---@field date_time_formats string[] List of lua patterns for detecting date & time in YAML.
 ---

--- a/lua/markview/health.lua
+++ b/lua/markview/health.lua
@@ -466,6 +466,28 @@ health.check = function ()
 
 	------------------------------------------------------------------------------------------ 
 
+	vim.health.start("📂 Runtime path:")
+
+	if _G.__mkv_has_rtp_error == true then
+		vim.health.error(
+			"Runtime: `nvim-treesitter` is loaded before `markview.nvim`! It is recommened to change their load order!"
+		);
+
+		vim.health.info(
+			"NOTE: This can lead to incorrect `tree-sitter` query files being loaded, syntax highlighting may look odd!"
+		);
+	else
+		vim.health.ok(
+			"Runtime: `nvim-treesitter` isn't loaded before `markview.nvim`."
+		);
+
+		vim.health.info(
+			"NOTE: If you have changed the directory name of `nvim-treesitter` or `markview.nvim`, the result will be inaccurate!"
+		);
+	end
+
+	------------------------------------------------------------------------------------------ 
+
 	vim.health.start("💡 Parsers:")
 
 	if pcall(require, "nvim-treesitter") then

--- a/lua/markview/spec.lua
+++ b/lua/markview/spec.lua
@@ -111,6 +111,9 @@ end
 ---@type markview.config
 spec.default = {
 	experimental = {
+		check_rtp = true,
+		check_rtp_message = true,
+
 		date_formats = {
 			"^%d%d%d%d%-%d%d%-%d%d$",      --- YYYY-MM-DD
 			"^%d%d%-%d%d%-%d%d%d%d$",      --- DD-MM-YYYY, MM-DD-YYYY

--- a/plugin/markview.lua
+++ b/plugin/markview.lua
@@ -2,7 +2,7 @@
 local augroup = vim.api.nvim_create_augroup("markview", { clear = true });
 
 --- Checks errors in `runtime path`;
-local function rtp_check ()
+local function check_rtp ()
 	---|fS
 
 	local spec = require("markview.spec");
@@ -266,7 +266,7 @@ set_ts_directive();
 vim.api.nvim_create_autocmd("VimEnter", {
 	group = augroup,
 	callback = function ()
-		rtp_check();
+		check_rtp();
 		require("markview.highlights").setup();
 	end
 });
@@ -787,7 +787,10 @@ vim.api.nvim_create_autocmd({
 
  ------------------------------------------------------------------------------------------
 
----@type mkv.cmd_completion
+---@class markview.cmd_completions
+---
+---@field default fun(str: string): string[]
+---@field [string] fun(args: string[], cmd: string): string[]
 local get_complete_items = {
 	---|fS
 


### PR DESCRIPTION
Fixes the issue of incorrect query file being loaded if `nvim-treesitter` is loaded before `markview.nvim`.

Ref: #363, #332

------

>[!NOTE]
> It is still recommended to set `markview.nvim` as a dependency of `nvim-treesitter`(and not lazy load) to avoid this issue
