### PR TITLE
refactor: Fix code duplication for text wrapping & add compatibility changes for `breakindent` users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@
 
 Core features,
 
-+ Supports HTML, LaTeX, Markdown, Typst & YAML.
++ Supports previewing <code>HTML</code>, $LaTeX$, `Markdown`, `Typst` & `YAML`.
 + Highly customisable! Everything is done via the *configuration table* to ensure maximum customisability.
 + Hybrid editing mode! Allows editing & *previewing* files at the same time.
 + Split view! Allows previewing files on a separate window that updates in real-time!
-+ Partial *text wrap* support(only for markdown at the moment).
++ Previews are compatible with `'wrap'`(only for `markdown` at the moment).
 + Dynamic config that allows **any** option to be a function.
 + Dynamic `highlight groups` that automatically updates with the colorscheme.
 
@@ -240,12 +240,12 @@ Hybrid mode features,
 
 
 + *Node-based* edit range.
-  Clears the current nodes range of lines. Useful when editing lists, block quotes, code blocks, tables etc.
+  Clears a range of lines covered by the (named)`TSNode` under the cursor. Useful when editing lists, block quotes, code blocks, tables etc.
 
 + *Range-based* edit range.
   Clears the selected number of lines above & below the cursor.
 
-+ Supports multiple cursors to.
++ Works even when a `buffer` is being viewed by multiple `window`s.
 
 Internal Icon provider features,
 

--- a/lua/markview.lua
+++ b/lua/markview.lua
@@ -792,6 +792,24 @@ markview.actions = {
 		});
 		health.__child_indent_in();
 
+		---|fS 
+
+		--[[
+			fix(markdown): Restore `breakindent` before clearing.
+
+			We need to *restore* the original value of `breakindent`
+			to respect user preference(we need to check if a cached
+			value exists first).
+		]]
+
+		local win = vim.fn.win_findbuf(buffer)[1];
+
+		if vim.bo[buffer].ft == "markdown" and win and vim.w[win].__mkv_cached_breakindet then
+			vim.wo[win].breakindent = vim.w[win].__mkv_cached_breakindet;
+		end
+
+		---|fE
+
 		markview.state.buffer_states[buffer].enable = false;
 		markview.clear(buffer);
 
@@ -862,6 +880,25 @@ markview.actions = {
 			health.__child_indent_de();
 			return;
 		end
+
+		---|fS 
+
+		--[[
+			fix(markdown): Disable `breakindent` before rendering.
+
+			This is to prevent `text wrap support` from being broken due
+			to `breakindent` changing where wrapped text is shown.
+		]]
+
+		local win = vim.fn.win_findbuf(buffer)[1];
+
+		if vim.bo[buffer].ft == "markdown" and win then
+			-- warning: `breakindent` must be set before rendering!
+			vim.w[win].__mkv_cached_breakindet = vim.wo[win].breakindent;
+			vim.wo[win].breakindent = false;
+		end
+
+		---|fE
 
 		markview.render(buffer);
 

--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -3326,11 +3326,11 @@ markdown.__block_quote = function (buffer, item)
 		return;
 	end
 
-	local config;
+	---@type markview.config.markdown.block_quotes.opts
+	local config = spec.get({ "default" }, { source = main_config, eval_args = { buffer, item } });
 
 	if item.callout then
-		---@type markview.config.markdown.block_quotes.opts
-		config = spec.get(
+		config = vim.tbl_extend("force", config, spec.get(
 			{ string.lower(item.callout) },
 			{ source = main_config, eval_args = { buffer, item } }
 		) or spec.get(
@@ -3339,10 +3339,7 @@ markdown.__block_quote = function (buffer, item)
 		) or spec.get(
 			{ item.callout },
 			{ source = main_config, eval_args = { buffer, item } }
-		);
-	else
-		---@type markview.config.markdown.block_quotes.opts
-		config = spec.get({ "default" }, { source = main_config, eval_args = { buffer, item } });
+		));
 	end
 
 	local win = utils.buf_getwin(buffer);

--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -3481,6 +3481,7 @@ end
 markdown.__section = function (buffer, item)
 	---@type markview.config.markdown.headings?
 	local main_config = spec.get({ "markdown", "headings" }, { fallback = nil, eval_args = { buffer, item } });
+	local range = item.range;
 
 	if main_config == nil then
 		return;
@@ -3492,76 +3493,19 @@ markdown.__section = function (buffer, item)
 	local shift_width = main_config.org_shift_width or main_config.shift_width or 0;
 	local shift_char = main_config.org_shift_char or " ";
 
-	local win = utils.buf_getwin(buffer);
-
-	local width = vim.api.nvim_win_get_width(win);
-	local textoff = vim.fn.getwininfo(win)[1].textoff;
-	local winx = vim.api.nvim_win_get_position(win)[2];
-
-	local range = item.range;
-
 	for l = range.row_start, range.row_end, 1  do
 		local l_index = (l - range.row_start) + 1;
-
 		local line = item.text[l_index];
-		local start = false;
 
-		if vim.fn.strdisplaywidth(line) <= width - textoff then
-			-- Lines that are too short should be skipped.
-			goto skip_line;
-		end
+		require("markview.wrap").wrap_indent(buffer, {
+			line = line,
+			row = l,
+			indent = {
+				{ string.rep(shift_char, math.max(0, shift_width * (item.level - 1))) }
+			},
 
-		for c = 1, vim.fn.strdisplaywidth(line) do
-			--- `l` should be 1-indexed.
-			---@type integer
-			local x = vim.fn.screenpos(win, l + 1, c).col - (winx + textoff);
-
-			if x == 1 then
-				if start == false then
-					start = true;
-					goto continue;
-				end
-
-				local extmark = get_extmark(buffer, l, c - 1);
-				register_wrap(l, c - 1);
-
-				if extmark ~= nil then
-					local id = extmark[1];
-					local virt_text = extmark[4].virt_text;
-
-					vim.api.nvim_buf_set_extmark(buffer, markdown.ns, l, c - 1, {
-						id = id,
-
-						undo_restore = false, invalidate = true,
-						right_gravity = false,
-
-						virt_text_pos = "inline",
-						---@diagnostic disable-next-line
-						virt_text = vim.list_extend(virt_text, {
-							{ string.rep(shift_char, math.max(0, shift_width * (item.level - 1))) }
-						}),
-
-						hl_mode = "combine",
-					});
-				else
-					vim.api.nvim_buf_set_extmark(buffer, markdown.ns, l, c - 1, {
-						undo_restore = false, invalidate = true,
-						right_gravity = false,
-
-						virt_text_pos = "inline",
-						virt_text = {
-							{ string.rep(shift_char, math.max(0, shift_width * (item.level - 1))) }
-						},
-
-						hl_mode = "combine",
-					});
-				end
-			end
-
-		    ::continue::
-		end
-
-		::skip_line::
+			ns = markdown.ns
+		});
 	end
 end
 

--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -3369,7 +3369,10 @@ end
 ---@param item markview.parsed.markdown.list_items
 markdown.__list_item = function (buffer, item)
 	---@type markview.config.markdown.list_items?
-	local main_config = spec.get({ "markdown", "list_items" }, { fallback = nil });
+	local main_config = spec.get({ "markdown", "list_items" }, {
+		fallback = nil,
+		eval_args = { buffer, item }
+	});
 	local range = item.range;
 
 	if not main_config then
@@ -3378,15 +3381,13 @@ markdown.__list_item = function (buffer, item)
 
 	---@type markview.config.markdown.list_items.ordered | markview.config.markdown.list_items.unordered
 	local config;
-	local shift_width, indent_size = main_config.shift_width or 1, main_config.indent_size or 1;
 
-	if type(shift_width) ~= "number" then
-		shift_width = 1;
-	end
 
-	if type(indent_size) ~= "number" then
-		indent_size = 1;
-	end
+	local shift_width = type(main_config.shift_width) == "number" and main_config.shift_width or 1;
+	local indent_size = type(main_config.indent_size) == "number" and main_config.indent_size or 1;
+
+	---@cast indent_size integer
+	---@cast shift_width integer
 
 	if item.marker == "-" then
 		config = spec.get({ "marker_minus" }, {

--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -3271,35 +3271,6 @@ end
  -----------------------------------------------------------------------------------------
 
 
---- Places where the list items were wrapped.
----@type { [integer]: integer[] }
-markdown.__list_wraps = {};
-
-local get_extmark = function (buffer, lnum, col)
-	local extmarks = vim.api.nvim_buf_get_extmarks(buffer, markdown.ns, { lnum, col }, { lnum, col + 1 }, {
-		details = true,
-		type = "virt_text"
-	});
-
-	return extmarks[1];
-end
-
-local register_wrap = function (lnum, col)
-	if vim.islist(markdown.__list_wraps[lnum]) == false then
-		markdown.__list_wraps[lnum] = {};
-	end
-
-	table.insert(markdown.__list_wraps[lnum], col);
-end
-
-local has_wrap = function (lnum, col)
-	if vim.islist(markdown.__list_wraps[lnum]) == false then
-		return false;
-	else
-		return vim.list_contains(markdown.__list_wraps[lnum], col);
-	end
-end
-
 --- Renders wrapped block quotes, callouts & alerts.
 ---@param buffer integer
 ---@param item markview.parsed.markdown.block_quotes
@@ -3381,7 +3352,6 @@ markdown.__list_item = function (buffer, item)
 
 	---@type markview.config.markdown.list_items.ordered | markview.config.markdown.list_items.unordered
 	local config;
-
 
 	local shift_width = type(main_config.shift_width) == "number" and main_config.shift_width or 1;
 	local indent_size = type(main_config.indent_size) == "number" and main_config.indent_size or 1;
@@ -3550,8 +3520,6 @@ end
 ---@param buffer integer
 ---@param content table
 markdown.post_render = function (buffer, content)
-	markdown.__list_wraps = {};
-
 	local custom = spec.get({ "renderers" }, { fallback = {} });
 
 	for _, item in ipairs(content or {}) do

--- a/lua/markview/wrap.lua
+++ b/lua/markview/wrap.lua
@@ -1,0 +1,96 @@
+---@class markview.wrap.opts
+---
+---@field indent [ string, string? ][] Text to use as indentation in wraps.
+---@field line string Text to wrap.
+---@field ns integer Namespace for `extmarks`.
+---@field row integer Row of line(**0-indexed**).
+
+------------------------------------------------------------------------------
+
+--[[ Text wrapping for `markview.nvim`. ]]
+local wrap = {};
+local utils = require("markview.utils");
+
+--[[ Gets extmark for `[ lnum, col ]`. ]]
+---@param buffer integer
+---@param ns integer
+---@param lnum integer
+---@param col integer
+---@return vim.api.keyset.get_extmark_item
+wrap.get_extmark = function (buffer, ns, lnum, col)
+	local extmarks = vim.api.nvim_buf_get_extmarks(buffer, ns, { lnum, col }, { lnum, col + 1 }, {
+		details = true,
+		type = "virt_text"
+	});
+
+	return extmarks[1];
+end
+
+--[[ Provides `wrapped indentation` to some text. ]]
+---@param buffer integer
+---@param opts markview.wrap.opts
+wrap.wrap_indent = function (buffer, opts)
+	---|fS
+
+	local win = utils.buf_getwin(buffer);
+
+	local win_width = vim.api.nvim_win_get_width(win);
+	local textoff = vim.fn.getwininfo(win)[1].textoff;
+	local W = win_width - textoff;
+
+	if vim.fn.strdisplaywidth(opts.line or "") < W then
+		return;
+	end
+
+	local win_x = vim.api.nvim_win_get_position(win)[2];
+	local passed_start = false;
+
+	for c = 1, vim.fn.strdisplaywidth(opts.line or "") do
+		--- `l` should be 1-indexed.
+		---@type integer
+		local x = vim.fn.screenpos(win, opts.row + 1, c).col - (win_x + textoff);
+
+		if x ~= 1 then
+			goto continue;
+		elseif passed_start == false then
+			passed_start = true;
+			goto continue;
+		end
+
+		local extmark = wrap.get_extmark(buffer, opts.ns, opts.row, c - 1);
+
+		if extmark ~= nil then
+			local id = extmark[1];
+			local virt_text = extmark[4].virt_text;
+
+			vim.api.nvim_buf_set_extmark(buffer, opts.ns, opts.row, c - 1, {
+				id = id,
+
+				undo_restore = false, invalidate = true,
+				right_gravity = false,
+
+				virt_text_pos = "inline",
+				---@diagnostic disable-next-line: param-type-mismatch
+				virt_text = vim.list_extend(virt_text, opts.indent or {}),
+
+				hl_mode = "combine",
+			});
+		else
+			vim.api.nvim_buf_set_extmark(buffer, opts.ns, opts.row, c - 1, {
+				undo_restore = false, invalidate = true,
+				right_gravity = false,
+
+				virt_text_pos = "inline",
+				virt_text = opts.indent or {},
+
+				hl_mode = "combine",
+			});
+		end
+
+		::continue::
+	end
+
+	---|fE
+end
+
+return wrap;

--- a/test.md
+++ b/test.md
@@ -1,0 +1,11 @@
+>[!NOTE]
+> * hi
+>     + Hello world this is some text. Hello world this is some text. Hello world this is some text
+
+
+* hi
+    + Hello world this is some text. Hello world this is some text. Hello world this is some text
+
+<!--
+vim:wrap:
+-->


### PR DESCRIPTION
This PR contains the following changes,

- Separated the text wrapping functionality to it's own module(`markview.wrap`).
- Removed unused boilerplates & removed use of `__list_wraps` internally.
- Changed condition used for detecting short lines(display width must be **smaller** then window width, instead of smaller *or* equal).
- Autocmds & `:Markview`(& it's sub-commands) now disable `'breakindent'` when rendering to prevent breakage of text wrap support.

Closes #381 