### PR TITLE
Problem with org_indent not handling indention correctly

### DIFF
--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -2176,7 +2176,7 @@ markdown.section = function (buffer, item)
 
 			virt_text_pos = "inline",
 			virt_text = {
-				{ string.rep(shift_char, math.max(0, shift_width * (item.level - 1))) }
+				{ string.rep(shift_char, math.max(0, shift_width)) }
 			},
 
 			right_gravity = false,

--- a/lua/markview/renderers/markdown.lua
+++ b/lua/markview/renderers/markdown.lua
@@ -2170,7 +2170,7 @@ markdown.section = function (buffer, item)
 
 	local range = item.range;
 
-	for l = range.row_start + 1, range.row_end do
+	for l = range.row_start + 1, range.row_end - 1 do
 		vim.api.nvim_buf_set_extmark(buffer, markdown.ns, l, 0, {
 			undo_restore = false, invalidate = true,
 


### PR DESCRIPTION
With org_indent enabled, the indention of the next heading was done multiple times after the heading level 2.
<img width="647" height="123" alt="image" src="https://github.com/user-attachments/assets/7b9390fc-04e2-42f4-9dc5-fc50f8359f3c" />
Also the next heading at a lower level then the current heading would be indented to the current level.
<img width="504" height="116" alt="image" src="https://github.com/user-attachments/assets/7ba70065-3e8f-4d99-96eb-7e34c653f97b" />
