### PR TITLE
Improve performance by short-circuiting wrapping indents at a certain point

### DIFF
--- a/lua/markview/wrap.lua
+++ b/lua/markview/wrap.lua
@@ -55,7 +55,7 @@ wrap.wrap_indent = function (buffer, opts)
 		if x == 0 then
 			goto continue;
 		if x ~= 1 then
-			goto be_done;
+			return;
 		elseif passed_start == false then
 			passed_start = true;
 			goto continue;
@@ -82,8 +82,6 @@ wrap.wrap_indent = function (buffer, opts)
 
 		::continue::
 	end
-
-	::be_done::
 
 	---|fE
 end


### PR DESCRIPTION
I was noticing some really annoying slowness on main today, so I finally decided to poke at it. After profiling with [profile.nvim](https://github.com/stevearc/profile.nvim), it seemed that the `vim.fn.screenpos` in this `wrap_indent` loop was getting hammered a lot and that was taking up a lot of cpu time.

So to fix that, I just made this loop short circuit when we hit a character that is past position 1 in the line. As far as I can tell, this function only indents at the beginning of the line, so once we hit a character that's not displayed at the first index, we can be confident that we're done with indents for this line, and we can just return.

This PR also makes some other micro-optimizations, such as computing things once instead of twice a few times.

From some basic testing of markdown files, this completely gets rid of the performance problem while keeping everything looking the same. Someone else should probably look over it to make sure I'm not crazy, though; I don't write lua very often.