### PR TITLE
doc: Change double quotes to single quotes in vim-plug install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Fonts,
 Add this to your plugin list.
 
 ```vim
-Plug "OXY2DEV/markview.nvim"
+Plug 'OXY2DEV/markview.nvim'
 ```
 
 ### 💤 Lazy.nvim


### PR DESCRIPTION
Very small change for better copy-pastability.
Using double quotes in a vim-plug configuration file throws an error:
<img width="977" height="492" alt="double-quote-error" src="https://github.com/user-attachments/assets/24309f7c-46f9-4078-aab8-3f7f3d6d71fb" />
Changing the double quotes to single quotes allows installation as expected.

This might be an obvious thing to power users! I may only have caught this as I am just learning to use neovim and exploring the ecosystem, and this happened to be the first plugin I installed. :)

For more context on why this occurs:
https://github.com/junegunn/vim-plug/issues/33