### PR TITLE
perf(spec): don't double eval func in `to_static`

### DIFF
--- a/lua/markview/spec.lua
+++ b/lua/markview/spec.lua
@@ -301,8 +301,8 @@ spec.get = function (keys, opts)
 			return val;
 		end
 
-		local ok, res = pcall(val, unpack(args or {}))
-		  return ok and res or nil
+		local ok, res = pcall(val, unpack(args or {}));
+		return ok and res or nil;
 	end
 
 	---@param index integer | string


### PR DESCRIPTION
Thanks for all your hard work on a great plugin!

**Changes**:
I noticed that in `spec.get`'s `to_static` function that functions are called twice (once to pcall and once to get result) when this could be combined into one call. Given that spec.get is called often throughout the codebase, this could be a reasonable perf improvement, though I have no good way of testing this atm.

If you have any contributor recs or guidelines, I'd love to help further.