### PR TITLE
health: initialize health.log to avoid ipairs(nil) error

### DIFF
--- a/lua/markview/health.lua
+++ b/lua/markview/health.lua
@@ -4,6 +4,7 @@ health.depth = 0;
 
 ---@type table[]
 health.history = {};
+health.log = {};
 
 --- Print log messages.
 ---@param msg table


### PR DESCRIPTION
Initialize health.log as an empty table to avoid a runtime error when running :checkhealth for markview (ipairs expected a table). This is a one-line defensive fix.