### PR TITLE
Fix: no longer overriding blink-cmp per_filetype sources

### DIFF
--- a/lua/markview/integrations.lua
+++ b/lua/markview/integrations.lua
@@ -23,7 +23,7 @@ integrations.register_blink_source = function ()
 	local function handle_filetype(filetype, config)
 		---|fS
 
-		if type(config) == "table" and vim.islist(config) then
+		if type(config) == "table" then
 			---@cast config table
 			if vim.list_contains(config, "markview") then
 				-- `markview` is already used as a source.
@@ -31,7 +31,7 @@ integrations.register_blink_source = function ()
 			end
 
 			-- If the config sources is a list we extend the list of sources.
-			blink_config.sources.per_filetype[filetype] = vim.list_extend(config, { "markview" });
+			blink_config.sources.per_filetype[filetype] = vim.list_extend(vim.deepcopy(config), { "markview" });
 		else
 			---@cast config fun(): table
 


### PR DESCRIPTION
Closes #459 

I went ahead and wrote a smarter integration function for blink-cmp. It basically checks if the user provided a per_filetype configuration, and if they did, extend that instead of the defaults. It seems to be working in my tests.

This is just a quick and dirty solution that I wrote to fix my own workflow. Let me know if there are any changes needed to fix this, or if this solution is not appropriate.