### PR TITLE
fix: correct typo and function call in hybridToggle action

### DIFF
--- a/lua/markview/actions.lua
+++ b/lua/markview/actions.lua
@@ -735,7 +735,7 @@ end
 
 ------------------------------------------------------------------------------
 
-actions.hybridTtoggle = function (buffer)
+actions.hybridToggle = function (buffer)
 	---|fS
 
 	buffer = buffer or vim.api.nvim_get_current_buf();
@@ -750,9 +750,9 @@ actions.hybridTtoggle = function (buffer)
 	end
 
 	if old_state.hybrid_mode == true then
-		actions.hybrid_disable();
+		actions.hybridDisable();
 	else
-		actions.hybrid_enable();
+		actions.hybridEnable();
 	end
 
 	---|fE


### PR DESCRIPTION
Hi! I was exploring the hybrid mode features and noticed that the Markview HybridToggle command wasn't working. It was due to small typos in hybridToggle function. 

Thanks for such a great plugin!

