### PR TITLE
fix(latex): render unbraced greek sub/sup symbols

### DIFF
--- a/lua/markview/parsers/latex.lua
+++ b/lua/markview/parsers/latex.lua
@@ -1,5 +1,6 @@
 --- HTML parser for `markview.nvim`
 local latex = {};
+local symbols = require("markview.symbols");
 
 --- `string.gsub()` with support for multiple patterns.
 ---@param text string
@@ -13,6 +14,29 @@ local function bulk_gsub (text, gsubs)
 	end
 
 	return _o;
+end
+
+---@param symbol_map table<string, string>
+---@return string[]
+local function style_symbol_commands(symbol_map)
+	local commands = {};
+
+	for name, _ in pairs(symbol_map or {}) do
+		if type(name) == "string" and #name > 1 and name:match("^[A-Za-z]+$") then
+			table.insert(commands, "\\" .. name);
+		end
+	end
+
+	table.sort(commands, function (a, b)
+		return #a > #b;
+	end);
+
+	return commands;
+end
+
+---@return string[]
+local function previewable_symbol_commands()
+	return style_symbol_commands(symbols.entries);
 end
 
 --- Checks if the given node is inside of `\text{}`.
@@ -304,23 +328,7 @@ latex.subscript = function (_, TSNode, text, range)
 	local node = TSNode;
 	local level, preview = 0, true;
 
-	local supported_symbols = {
-		"\\beta",
-		"\\gamma",
-		"\\rho",
-		"\\phi",
-		"\\chi",
-
-		-- See OZU2DEV/markview#379
-		"\\epsilon",
-		"\\omicron",
-		"\\alpha",
-		"\\eta",
-		"\\nu",
-		"\\rho",
-		"\\upsilon",
-		"\\sigma",
-	}
+	local supported_symbols = previewable_symbol_commands();
 
 	for _, line in ipairs(text) do
 		if bulk_gsub(line, supported_symbols):match("%\\") then
@@ -359,26 +367,7 @@ latex.superscript = function (_, TSNode, text, range)
 	local node = TSNode;
 	local level, preview = 0, true;
 
-	local supported_symbols = {
-		"\\alpha",
-		"\\beta",
-		"\\gamma",
-		"\\delta",
-		"\\epsilon",
-		"\\theta",
-		"\\iota",
-		"\\Phi",
-		"\\varphi",
-		"\\chi",
-
-		-- See OZU2DEV/markview#379
-		"\\omicron",
-		"\\eta",
-		"\\nu",
-		"\\rho",
-		"\\upsilon",
-		"\\sigma",
-	}
+	local supported_symbols = previewable_symbol_commands();
 
 	for _, line in ipairs(text) do
 		if bulk_gsub(line, supported_symbols):match("%\\") then

--- a/lua/markview/renderers/latex.lua
+++ b/lua/markview/renderers/latex.lua
@@ -4,6 +4,22 @@ local symbols = require("markview.symbols");
 local spec = require("markview.spec");
 local utils = require("markview.utils");
 
+---@param text string?
+---@return string?
+local function normalize_style_symbol(text)
+	if type(text) ~= "string" or text == "" then
+		return nil;
+	end
+
+	local key = text:sub(2);
+
+	if key:match("^\\") then
+		key = key:sub(2);
+	end
+
+	return key ~= "" and key or nil;
+end
+
 --- Cached values.
 latex.cache = {
 	font_regions = {},
@@ -449,20 +465,28 @@ latex.subscript = function (buffer, item)
 				end_col = range.col_end,
 				conceal = "",
 			});
-		elseif symbols.subscripts[item.text[1]:sub(2)] then
-			vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start, {
-				undo_restore = false, invalidate = true,
-				end_col = range.col_start + 1,
-				conceal = ""
-			});
+		else
+			local symbol_key = normalize_style_symbol(item.text[1]);
+			local symbol_text = symbol_key and (
+				symbols.subscripts[symbol_key] or
+				symbols.entries[symbol_key]
+			);
 
-			vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start + 1, {
-				undo_restore = false, invalidate = true,
-				virt_text_pos = "overlay",
-				virt_text = { { symbols.subscripts[item.text[1]:sub(2)], utils.set_hl(hl) } },
+			if symbol_text then
+				vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start, {
+					undo_restore = false, invalidate = true,
+					end_col = range.col_start + 1,
+					conceal = ""
+				});
 
-				hl_mode = "combine"
-			});
+				vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start + 1, {
+					undo_restore = false, invalidate = true,
+					virt_text_pos = "overlay",
+					virt_text = { { symbol_text, utils.set_hl(hl) } },
+
+					hl_mode = "combine"
+				});
+			end
 		end
 	end
 
@@ -562,20 +586,28 @@ latex.superscript = function (buffer, item)
 				end_col = range.col_end,
 				conceal = "",
 			});
-		elseif symbols.superscripts[item.text[1]:sub(2)] then
-			vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start, {
-				undo_restore = false, invalidate = true,
-				end_col = range.col_start + 1,
-				conceal = ""
-			});
+		else
+			local symbol_key = normalize_style_symbol(item.text[1]);
+			local symbol_text = symbol_key and (
+				symbols.superscripts[symbol_key] or
+				symbols.entries[symbol_key]
+			);
 
-			vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start + 1, {
-				undo_restore = false, invalidate = true,
-				virt_text_pos = "overlay",
-				virt_text = { { symbols.superscripts[item.text[1]:sub(2)], utils.set_hl(hl) } },
+			if symbol_text then
+				vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start, {
+					undo_restore = false, invalidate = true,
+					end_col = range.col_start + 1,
+					conceal = ""
+				});
 
-				hl_mode = "combine"
-			});
+				vim.api.nvim_buf_set_extmark(buffer, latex.ns, range.row_start, range.col_start + 1, {
+					undo_restore = false, invalidate = true,
+					virt_text_pos = "overlay",
+					virt_text = { { symbol_text, utils.set_hl(hl) } },
+
+					hl_mode = "combine"
+				});
+			end
 		end
 	end
 

--- a/test/latex.md
+++ b/test/latex.md
@@ -42,6 +42,10 @@ Some math in a line, $1+2=3$.
 
 $$
 a_s
+b_\alpha
+b_\delta
+b_\theta
+b_{\alpha}
 b_{some text + \gamma}
 $$
 
@@ -49,6 +53,10 @@ $$
 
 $$
 c^5
+d^\alpha
+d^\delta
+d^\theta
+d^{\alpha}
 d^{Some other text + \alpha}
 $$
 
@@ -59,10 +67,15 @@ $$
 \Alpha \Beta \Gamma \Delta \Eta \Theta \Xi \Pi
 $$
 
+; Mixed expression
+
+$$
+M_\alpha = \int dq, q^2 g_\alpha(q) x_\alpha(q)
+$$
+
 ; Text mode
 
 $$
 \text{a^2 + 2ab + b^2}
 a^2 + 2ab + b^2
 $$
-


### PR DESCRIPTION
## Summary
- normalize unbraced sub/sup style-symbol lookups so `_\alpha` and `^\alpha` resolve through the existing subscript/superscript glyph maps
- fall back to regular symbol glyphs for unbraced style-symbols when no dedicated Unicode sub/sup form exists, so cases like `_\delta` and `_\theta` still render as symbols instead of raw TeX
- derive parser fake-preview allowlists from `markview.symbols.entries` to keep parser and renderer behavior aligned
- add regression examples for unbraced and braced greek sub/sup forms in `test/latex.md`

## Reproduction
Before this change, plain `\alpha` rendered correctly, but unbraced forms such as `q_\alpha` and `q^\alpha` stayed as raw TeX in Markview preview. The same issue affected other greek symbol commands in unbraced sub/sup form.

## Verification
- headless render check now emits `ₐ` for `_\alpha`, `δ` for `_\delta`, and `θ` for `_\theta`
- headless render check now emits `ᵅ` for `^\alpha`, `ᵟ` for `^\delta`, and `ᶿ` for `^\theta`
- braced forms `_{\alpha}` and `^{\alpha}` still render correctly