### PR TITLE
fix(tostring): support balanced parentheses in URL link destinations

### DIFF
--- a/lua/markview/renderers/markdown/tostring.lua
+++ b/lua/markview/renderers/markdown/tostring.lua
@@ -631,7 +631,12 @@ local code = lpeg.C( at_valid * lpeg.P("`")^1 * code_content^1 * lpeg.P("`")^1 )
 
 local hyperlink_content = lpeg.P("\\]") + ( 1 - lpeg.P("]") );
 local hyperlink_no_src = lpeg.C( lpeg.P("[") * hyperlink_content^0 * lpeg.P("]") ) / md_str.hyperlink_no_src;
-local src_content = lpeg.P("\\)") + ( 1 - lpeg.S(") \t") );
+-- Supports balanced parentheses in URLs per CommonMark spec §6.7:
+-- https://spec.commonmark.org/0.31.2/#link-destination
+local src_content = lpeg.P{
+	"src";
+	src = lpeg.P("\\)") + (lpeg.P("(") * lpeg.V("src")^0 * lpeg.P(")")) + ( 1 - lpeg.S(") \t") );
+};
 local hyperlink_src = lpeg.C( lpeg.P("[") * hyperlink_content^0 * lpeg.P("](") * src_content^0 * lpeg.P(")") ) / md_str.hyperlink_src;
 local hyperlink = hyperlink_src + hyperlink_no_src;
 


### PR DESCRIPTION
### Problem

Table columns containing hyperlinks with parentheses in their URLs (e.g. API documentation links like `nvim_buf_set_lines()`) render needlessly wide. In narrow windows, this can cause markview to skip rendering the table entirely.

### Root Cause

The lpeg `src_content` pattern in `tostring.lua` rejects **all** unescaped `)` inside URLs:

```lua
local src_content = lpeg.P("\\)") + ( 1 - lpeg.S(") \t") );
```

For a link like `[API](https://neovim.io/doc/user/api.html#nvim_buf_set_lines()-nvim_buf_get_lines()-...)`, the pattern matches only up to `set_lines(` and consumes the `)` as the link's closing delimiter. The unmatched tail spills into the visible text output, inflating the column width calculation from ~7 to 69 characters.

### Fix

Replace the flat pattern with a recursive lpeg grammar that allows **balanced** `(...)` groups inside URL destinations, per [CommonMark spec §6.7](https://spec.commonmark.org/0.31.2/#link-destination):

```lua
local src_content = lpeg.P{
	"src";
	src = lpeg.P("\\)") + (lpeg.P("(") * lpeg.V("src")^0 * lpeg.P(")")) + ( 1 - lpeg.S(") \t") );
};
```

Both `hyperlink_src` and `img_src` benefit since they share `src_content`.
