### PR TITLE
fix(tostring): resolve emoji shorthands to Unicode for correct table column widths

### DIFF
--- a/lua/markview/renderers/markdown/tostring.lua
+++ b/lua/markview/renderers/markdown/tostring.lua
@@ -245,6 +245,16 @@ md_str.emoji = function (match)
 	end
 
 	local removed = string.gsub(match, "^:", ""):gsub(":$", "");
+
+	--- Resolve to the actual Unicode emoji so that
+	--- strdisplaywidth() returns the correct on-screen
+	--- width (typically 2) instead of the shortcode name
+	--- length (e.g. "rocket" = 6).
+	local symbols = require("markview.symbols");
+	if symbols.shorthands and symbols.shorthands[removed] then
+		return symbols.shorthands[removed];
+	end
+
 	return removed;
 
 	---|fE


### PR DESCRIPTION
**Problem**

Table columns containing emoji shortcodes (e.g. `:rocket:`, `:sparkles:`) render with misaligned borders. The column width calculation overestimates cells that contain emojis.

**Root cause**

`md_str.emoji()` in `tostring.lua` strips the colons from shortcodes but never resolves them to the actual Unicode character:

| Shortcode | `tostring` returned | `strdisplaywidth` | Actual display | `strdisplaywidth` | Δ |
|---|---|---|---|---|---|
| `:sparkles:` | `sparkles` | 8 | ✨ | 2 | **+6** |
| `:rocket:` | `rocket` | 6 | 🚀 | 2 | **+4** |
| `:wrench:` | `wrench` | 6 | 🔧 | 2 | **+4** |

The inline renderer (`inline.emoji`) correctly replaces the shortcode with the Unicode symbol via `symbols.shorthands[]`, but the width-calculation path never did — so `col_widths` was inflated by the difference.

**Fix**

Resolve the shortcode through `symbols.shorthands[]` in `md_str.emoji()` (falling back to the stripped name if the symbol isn't found), matching what the inline renderer actually displays.
