### PR TITLE
fix(tostring): add footnote pattern to LPeg parser for correct table column widths

### DIFF
--- a/lua/markview/renderers/markdown/tostring.lua
+++ b/lua/markview/renderers/markdown/tostring.lua
@@ -62,6 +62,7 @@ md_str.update_cache = function ()
 		hyperlinks = spec.get({ "markdown_inline", "hyperlinks" }, { fallback = nil }),
 		images = spec.get({ "markdown_inline", "images" }, { fallback = nil }),
 		inline_codes = spec.get({ "markdown_inline", "inline_codes"}, { fallback = nil }),
+		footnotes = spec.get({ "markdown_inline", "footnotes" }, { fallback = nil }),
 		internal_links = spec.get({ "markdown_inline", "internal_links" }, { fallback = nil }),
 		uri_autolinks = spec.get({ "markdown_inline", "uri_autolinks" }, { fallback = nil }),
 	};
@@ -301,6 +302,46 @@ md_str.internal = function (match)
 	else
 		return removed;
 	end
+
+	---|fE
+end
+
+---@param match string
+---@return string
+md_str.footnote = function (match)
+	---|fS
+
+	local label = string.gsub(match, "^%[%^", ""):gsub("%]$", "");
+
+	if md_str.cached_config and md_str.cached_config.footnotes then
+		---@type markview.config.__inline?
+		local config = require("markview.utils").match(md_str.cached_config.footnotes, label, {
+			eval_args = {
+				md_str.buffer,
+				{
+					class = "inline_footnote",
+					text = { match },
+
+					label = label,
+				}
+			}
+		});
+
+		if config then
+			return table.concat({
+				config.corner_left or "",
+				config.padding_left or "",
+
+				config.icon or "",
+				label,
+
+				config.padding_right or "",
+				config.corner_right or "",
+			}, "");
+		end
+	end
+
+	return label;
 
 	---|fE
 end
@@ -629,6 +670,9 @@ local bold_italic = s_bold_italic + u_bold_italic;
 local code_content = lpeg.P("\\`") + ( 1 - lpeg.P("`") );
 local code = lpeg.C( at_valid * lpeg.P("`")^1 * code_content^1 * lpeg.P("`")^1 ) / md_str.code;
 
+local footnote_label_char = lpeg.R("09", "az", "AZ") + lpeg.S("-_.");
+local footnote = lpeg.C( lpeg.P("[^") * footnote_label_char^1 * lpeg.P("]") ) / md_str.footnote;
+
 local hyperlink_content = lpeg.P("\\]") + ( 1 - lpeg.P("]") );
 local hyperlink_no_src = lpeg.C( lpeg.P("[") * hyperlink_content^0 * lpeg.P("]") ) / md_str.hyperlink_no_src;
 -- Supports balanced parentheses in URLs per CommonMark spec §6.7:
@@ -678,7 +722,7 @@ local token = escape +
 	emoji + entity +
 	hl + block_ref + embed + internal +
 	email + auto +
-	img + hyperlink +
+	footnote + img + hyperlink +
 	code +
 	bold_italic + bold + italic +
 	any;


### PR DESCRIPTION
### Problem

The `tostring` module (`lua/markview/renderers/markdown/tostring.lua`) is used to compute the visual (post-conceal) width of table cells for column alignment. It had no pattern for footnote references like `[^1]` or `[^label]`.

These fell through to the `hyperlink_no_src` pattern, which strips `[` and `]` but **keeps the `^` character**, producing a visual string one character too wide.

| Input | `tostring` returned | Actual renderer shows | Width error |
|---|---|---|---|
| `[^1]` | `󰌷 ^1` (width 4) | `󰯓 1` (width 3) | +1 |
| `[^long-descriptive-footnote-name]` | `󰌷 ^long-descriptive-footnote-name` (width 37) | `󰯓 long-descriptive-footnote-name` (width 36) | +1 |

This caused misaligned columns in any table row containing footnote references.

### Fix

Add a dedicated `footnote` LPeg pattern and capture function that:
- Matches `[^label]` syntax, placed **before** `hyperlink` in the token priority list
- Strips `[^` and `]` delimiters, matching the actual renderer behavior (`markdown_inline.lua` conceals 2 bytes `[^` and 1 byte `]`)
- Looks up the footnote config for icon/corner/padding decorations
- Returns the correct visual string for width measurement

### Verification

```
✅ [^1]              → width=3  (was 4)
✅ [^abc]            → width=5  (was 6)
✅ [^long-label]     → width=49 (was 50)
✅ [link](url)       → unchanged
✅ [text]            → unchanged
✅ ![img](url)       → unchanged
```
