### PR TITLE
fix(parser): nil check before calling parse on treesitter parser

### DIFF
--- a/lua/markview/parser.lua
+++ b/lua/markview/parser.lua
@@ -150,13 +150,13 @@ parser.init = function (buffer, from, to, cache)
 		return parser.content, parser.sorted;
 	end
 
-    vim.treesitter.get_parser(buffer):parse(true);
 	local root_parser = vim.treesitter.get_parser(buffer);
-
 	if not root_parser then
 		-- Can't find root parser.
 		return parser.content, parser.sorted;
 	end
+
+	root_parser:parse(true);
 
 	--[[
 		WARN: Recursion when parsing `asciidoc_inline` trees


### PR DESCRIPTION
## Summary
- Add nil check for `get_parser()` result before calling `:parse()`
- Fixes "attempt to index a nil value" error at `parser.lua:153`

## Root Cause
When `vim.treesitter.get_parser(buffer)` returns `nil`, the code was still calling `:parse(true)` on the nil value, causing the crash.

## Fix
Store the parser result in a variable, check for nil, then call `:parse()` only if parser exists.

## Related Issue
Fixes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)