### PR TITLE
[Fix] Fix rendering for non-braced LaTeX subscripts and superscipts

### DIFF
--- a/lua/markview/renderers/latex.lua
+++ b/lua/markview/renderers/latex.lua
@@ -449,7 +449,7 @@ latex.subscript = function (buffer, item)
 				end_col = range.col_end,
 				conceal = "",
 			});
-		elseif symbols.subscripts[item.text[1]:sub(3)] then
+		elseif symbols.subscripts[item.text[1]:sub(2)] then
 			if item.preview then
 				table.insert(latex.cache.style_regions.subscripts, item);
 			end
@@ -566,7 +566,7 @@ latex.superscript = function (buffer, item)
 				end_col = range.col_end,
 				conceal = "",
 			});
-		elseif symbols.superscripts[item.text[1]:sub(3)] then
+		elseif symbols.superscripts[item.text[1]:sub(2)] then
 			if item.preview then
 				table.insert(latex.cache.style_regions.superscripts, item);
 			end


### PR DESCRIPTION
  Non-braced subscripts and superscripts such as `_t` and `^2` were not rendered
  because their lookup conditions used `item.text[1]:sub(3)`.

  For inputs like `_t` or `^2`, `sub(3)` returns an empty string, so the condition
  fails even when the target character exists in `symbols.subscripts` or
  `symbols.superscripts`. The actual render paths already use
  `item.text[1]:sub(2)`, which correctly extracts the character after `_` or `^`.

  This change makes the lookup conditions use the same substring offset as the
  render lookup, allowing expressions like `M_t`, `G_t`, and `x^2` to render
  consistently with braced forms like `M_{t}` and `x^{2}`.

|LaTex command| Before | After |
  |---|---|---|
  |`M_t = \beta M_{t-1} + (1-\beta)G_t`| <img width="240" alt="image" src="https://github.com/user-attachments/assets/6091bf42-b71e-46f0-8b8c-ff52d27bd555" />| <img width="240" alt="image" src="https://github.com/user-attachments/assets/5d775307-e401-44df-8d5e-59903a052d17" />|
|`y^2 + y^2 \leq 1`|<img width="240" alt="image" src="https://github.com/user-attachments/assets/f055b5cb-d3da-423c-b240-fd96bba00780" />|<img width="240" alt="image" src="https://github.com/user-attachments/assets/a9bf18db-bbf0-434f-b0e8-4c2b73dd4034" />|

