### PR TITLE
fix(tostring): respect CommonMark flanking for word-attached emphasis

### DIFF
--- a/lua/markview/renderers/markdown/tostring.lua
+++ b/lua/markview/renderers/markdown/tostring.lua
@@ -661,21 +661,59 @@ local at_start = lpeg.P(function (_, i) return i == 1; end);
 local after_sp = lpeg.B(lpeg.S(" \t"));
 local at_valid = (at_start + after_sp);
 
+-- CommonMark flanking rules for `*` emphasis.
+--
+-- The `at_valid` guard (start-of-string or after whitespace) used by the
+-- underscore variants treats word-attached `*`/`**` as literal text, e.g.
+-- `I**'ll finish**`. The treesitter renderer, however, follows CommonMark's
+-- left/right-flanking delimiter rules and conceals such markers, so the width
+-- computed here disagreed with what is drawn and table borders drifted right.
+-- These predicates mirror treesitter's flanking decision for `*`.
+--
+-- Underscore (`_`) keeps the `at_valid` guard: CommonMark forbids intra-word
+-- `_` emphasis (e.g. `snake_case`), which `at_valid` already approximates.
+local punct = lpeg.S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+local space = lpeg.S(" \t");
+local sol = at_start;
+local eol = -lpeg.P(1);
+
+-- A run can OPEN emphasis when it is left-flanking: not followed by whitespace,
+-- and either not followed by punctuation, or preceded by whitespace/punct/start.
+-- `run` is the literal delimiter pattern (e.g. `lpeg.P("**")`); preceded-by is a
+-- zero-width look-behind placed before the run, followed-by a look-ahead after.
+local function flank_open (run)
+	local after_not_space = #(lpeg.P(1) - space);
+	local after_not_punct = #(lpeg.P(1) - space - punct);
+	local before_ws_punct = sol + lpeg.B(space) + lpeg.B(punct);
+
+	return (run * after_not_punct) + (before_ws_punct * run * after_not_space);
+end
+
+-- A run can CLOSE emphasis when it is right-flanking: not preceded by whitespace,
+-- and either not preceded by punctuation, or followed by whitespace/punct/end.
+local function flank_close (run)
+	local before_not_space = lpeg.B(lpeg.P(1) - space);
+	local before_not_punct = lpeg.B(lpeg.P(1) - space - punct);
+	local after_ws_punct = #(space + punct) + eol;
+
+	return (before_not_punct * run) + (before_not_space * run * after_ws_punct);
+end
+
 local s_italic_content = lpeg.P("\\*") + ( 1 - lpeg.P("*") );
 local u_italic_content = lpeg.P("\\_") + ( 1 - lpeg.P("_") );
-local s_italic = lpeg.C( lpeg.P("*") * s_italic_content^1 * lpeg.P("*") ) / md_str.italic;
+local s_italic = lpeg.C( flank_open(lpeg.P("*")) * s_italic_content^1 * flank_close(lpeg.P("*")) ) / md_str.italic;
 local u_italic = lpeg.C( lpeg.P("_") * u_italic_content^1 * lpeg.P("_") ) / md_str.italic;
-local italic = at_valid * (s_italic + u_italic);
+local italic = s_italic + (at_valid * u_italic);
 
 local s_bold_content = lpeg.P("\\*") + ( 1 - lpeg.P("*") );
 local u_bold_content = lpeg.P("\\_") + ( 1 - lpeg.P("_") );
-local s_bold = lpeg.C( lpeg.P("**") * s_bold_content^1 * lpeg.P("**") ) / md_str.bold;
+local s_bold = lpeg.C( flank_open(lpeg.P("**")) * s_bold_content^1 * flank_close(lpeg.P("**")) ) / md_str.bold;
 local u_bold = lpeg.C( lpeg.P("__") * u_bold_content^1 * lpeg.P("__") ) / md_str.bold;
-local bold = at_valid * (s_bold + u_bold);
+local bold = s_bold + (at_valid * u_bold);
 
 local s_bold_italic_content = lpeg.P("\\*") + ( 1 - lpeg.P("*") );
 local u_bold_italic_content = lpeg.P("\\_") + ( 1 - lpeg.P("_") );
-local s_bold_italic = lpeg.C( lpeg.P("*")^3 * s_bold_italic_content^1 * lpeg.P("*")^3 ) / md_str.bold_italic;
+local s_bold_italic = lpeg.C( flank_open(lpeg.P("*")^3) * s_bold_italic_content^1 * flank_close(lpeg.P("*")^3) ) / md_str.bold_italic;
 local u_bold_italic = lpeg.C( lpeg.P("_")^3 * u_bold_italic_content^1 * lpeg.P("_")^3 ) / md_str.bold_italic;
 local bold_italic = s_bold_italic + u_bold_italic;
 

--- a/test/tostring_word_attached_emphasis.md
+++ b/test/tostring_word_attached_emphasis.md
@@ -1,0 +1,41 @@
+; Word-attached emphasis in tables — tostring column width
+
+Emphasis markers glued to a word (`x**bold**`, `I**'ll**`) are concealed by the
+renderer per CommonMark flanking rules, so the column-width calculation in
+`renderers/markdown/tostring.lua` must account for them too. If it doesn't, the
+calculated width is larger than what is drawn and the right border drifts.
+
+Open this file and check that every right border lines up.
+
+### Bold glued to a word
+
+| Case                          | Example              |
+|-------------------------------|----------------------|
+| Before a letter               | x**bold** end        |
+| Before punctuation            | I**'ll finish** soon |
+| Before punctuation            | I**'d be** here      |
+| After a word + space (normal) | a **bold** b         |
+| Plain (control)               | just normal text     |
+
+### Italic glued to a word
+
+| Case                       | Example   |
+|----------------------------|-----------|
+| Italic before punctuation  | I*'ll* go |
+| Intra-word italic          | 2*3*4 ok  |
+| Plain italic (control)     | a *it* b  |
+
+### Underscore stays literal (no intra-word emphasis)
+
+| Case             | Example              |
+|------------------|----------------------|
+| snake_case       | a snake_case_id here |
+| Plain (control)  | just normal text     |
+
+### Conditionals cheat sheet (real-world)
+
+| Type  | Example                                                     |
+|-------|-------------------------------------------------------------|
+| 1st   | If you **help** me, I**'ll finish** sooner.                 |
+| Mixed | If I **had studied** medicine, I**'d be** a doctor **now**. |
+| Mixed | If I **weren't** so shy, I**'d have spoken** up yesterday.  |


### PR DESCRIPTION
> **Note:** this fix was prepared with the help of an LLM (Claude Opus 4.8). It has been reviewed and tested locally; flagging the authorship for transparency.

## Problem

Table columns are mis-sized when a cell contains an emphasis marker glued to a word, e.g. `I**'ll finish**` — the right border drifts to the right. Minimal repro (open in a buffer with markview enabled):

| Type | Example                                     |
|------|---------------------------------------------|
| 1st  | If you **help** me, I**'ll finish** sooner. |
| Mix  | If I **had studied** it, I**'d be** happy.  |

The `I**'ll finish**` / `I**'d be**` cells push the border out by a couple of columns relative to the other rows.

## Cause

`renderers/markdown/tostring.lua` computes the on-screen width used to size table columns. Its `*`/`**` rules were gated by an `at_valid` guard that only accepts emphasis at the start of the string or right after whitespace, so word-attached markers were treated as literal text and counted at full width. The actual renderer follows the treesitter parse, which applies CommonMark's left/right-flanking delimiter rules and conceals those markers, so the width calculation over-counted and the column was padded too wide.

For example, treesitter parses `I**'ll finish**` as a literal `*`, an emphasis span `*'ll finish*`, and a literal `*` — rendering `I*'ll finish*` (width 13), while `tostring()` reported width 15.

## Fix

Replace the `at_valid` guard for `*` emphasis with proper left/right-flanking predicates that mirror the treesitter decision, so the computed width matches what is drawn. Underscore (`_`) keeps the `at_valid` guard, since CommonMark forbids intra-word `_` emphasis (e.g. `snake_case`) which that guard already approximates. This only affects the width calculation; the rendered output is unchanged.

## Test

Adds `test/tostring_word_attached_emphasis.md`, a visual fixture in the style of `test/tostring_recursion.md`. Open it and confirm every right border lines up; without this change the word-attached rows drift.
