### PR TITLE
fix(latex): evaluate function-typed command configs

### DIFF
--- a/lua/markview/renderers/latex.lua
+++ b/lua/markview/renderers/latex.lua
@@ -83,7 +83,7 @@ latex.command = function (buffer, item)
 		return;
 	else
 		---@type markview.config.latex.commands.opts
-		config = utils.match(main_config, command_name, { default = false });
+		config = utils.match(main_config, command_name, { default = false, eval_args = { buffer, item } });
 
 		if type(config) ~= "table" or vim.tbl_isempty(config) == true then
 			return;


### PR DESCRIPTION
The commands config defines `sqrt`, `lvert`, and `lVert` as functions that return their config tables, but `utils.match()` was called without `eval_args`, so `spec.get()` never evaluated them. Pass `eval_args` so function-typed entries are called and return their config.
