### PR TITLE
fix(tostring): handle strikethrough markers in visual width calculation

### DIFF
--- a/lua/markview/renderers/markdown/tostring.lua
+++ b/lua/markview/renderers/markdown/tostring.lua
@@ -370,6 +370,21 @@ end
 
 ---@param match string
 ---@return string
+md_str.strikethrough = function (match)
+	---|fS
+
+	if string.match(match, "%s+%~%~$") then
+		return match;
+	end
+
+	local removed = string.gsub(match, "^%~%~", ""):gsub("%~%~$", "");
+	return removed;
+
+	---|fE
+end
+
+---@param match string
+---@return string
 md_str.italic = function (match)
 	---|fS
 
@@ -777,11 +792,14 @@ local emoji = lpeg.C( lpeg.P(":") * emoji_char^1 * lpeg.P(":") ) / md_str.emoji;
 local hl_content = lpeg.P("\\=") + ( 1 - lpeg.P("=") );
 local hl = lpeg.C( lpeg.P("==") * hl_content^1 * lpeg.P("==") ) / md_str.highlight;
 
+local strike_content = lpeg.P("\\~") + ( 1 - lpeg.P("~") );
+local strike = lpeg.C( lpeg.P("~~") * strike_content^1 * lpeg.P("~~") ) / md_str.strikethrough;
+
 local any = lpeg.P(1);
 
 local token = escape +
 	emoji + entity +
-	hl + block_ref + embed + internal +
+	hl + strike + block_ref + embed + internal +
 	email + auto +
 	footnote + img + hyperlink +
 	code +

--- a/test/tostring_strikethrough_width.md
+++ b/test/tostring_strikethrough_width.md
@@ -1,0 +1,34 @@
+; Strikethrough markers in tables — tostring column width
+Strikethrough delimiters (`~~text~~`) are concealed by the renderer, so the
+column-width calculation in `renderers/markdown/tostring.lua` must strip them
+too. If it doesn't, each `~~` pair adds 2 characters (4 per `~~text~~` span) to
+the computed width, so the calculated width is larger than what is drawn and the
+right border drifts to the right.
+Open this file and check that every right border lines up. The strikethrough
+rows should align exactly with the plain control rows below them.
+### Single strikethrough span
+| Case                     | Example              |
+|--------------------------|----------------------|
+| Strikethrough word       | ~~gone~~ text        |
+| Strikethrough phrase     | ~~all of this~~ here |
+| Plain (control, same len)| xxxxxxx text         |
+| Plain (control)          | just normal text     |
+### Multiple spans in one cell
+| Case                    | Example                    |
+|-------------------------|----------------------------|
+| Two spans               | ~~one~~ and ~~two~~ done   |
+| Span at end of cell     | keep ~~this dropped~~      |
+| Plain (control)         | one     and two     done   |
+### Strikethrough mixed with other emphasis
+| Case                       | Example                  |
+|----------------------------|--------------------------|
+| Strike + bold             | ~~old~~ **new**          |
+| Strike + italic           | ~~old~~ *new*            |
+| Strike + code             | ~~old~~ `new()`          |
+| Plain (control)           | old     new              |
+### Escaped tildes stay literal (not strikethrough)
+| Case                  | Example            |
+|-----------------------|--------------------|
+| Escaped tilde pair    | a \~\~literal\~\~ b |
+| Single tilde (approx) | about ~5 items     |
+| Plain (control)       | just normal text   |


### PR DESCRIPTION
Strikethrough delimiters (`~~text~~`) are concealed by the renderer, but the column-width calculation in `renderers/markdown/tostring.lua` didn't strip them. Each `~~` pair added 2 characters (4 per span) to the computed width, so table columns containing strikethrough were over-wide and the right border drifted.
                                                                                                                                                                                                                                                                                                                           
This adds an `md_str.strikethrough` handler plus an LPEG `strike` pattern to strip the `~~` delimiters, matching how `==highlight==` is already handled.
                                                                                                                                                                                                                                                                                                                           
A test fixture (`test/tostring_strikethrough_width.md`) is included, in the same style as `test/tostring_word_attached_emphasis.md`: strikethrough rows should align with the plain control rows. It covers single/multiple spans, mixing with bold/italic/code, and escaped/single tildes staying literal.
