### PR TITLE
fix(parser): strip blockquote continuation prefix from table rows

### DIFF
--- a/lua/markview/parsers/markdown.lua
+++ b/lua/markview/parsers/markdown.lua
@@ -885,7 +885,18 @@ markdown.table = function (_, _, text, range)
 	end
 
 	for l, line in ipairs(text) do
+		--- Strip block_continuation prefixes(e.g. `> `)
+		--- from lines after the first.
+		--- `get_node_text()` only applies col_start to line 1.
+		if l > 1 then
+			line = line:sub(range.col_start + 1);
+		end
+
 		local row_text = line;
+
+		if row_text == "" or row_text:match("^%s*$") then
+			goto continue;
+		end
 
 		if l == 1 then
 			header = line_processor(row_text);
@@ -917,6 +928,8 @@ markdown.table = function (_, _, text, range)
 		else
 			table.insert(rows, line_processor(row_text))
 		end
+
+		::continue::
 	end
 
 	local top_border, border_overlap = overlap(range.row_start);

--- a/test/blockquote_table.md
+++ b/test/blockquote_table.md
@@ -1,0 +1,36 @@
+; Tables inside blockquotes — parser continuation prefix
+A table nested in a blockquote has a `> ` (block continuation) prefix on every
+line. `get_node_text()` only strips the node's `col_start` from the *first*
+line, so lines 2+ keep the `> `. The lpeg row parser in
+`parsers/markdown.lua` then fails silently on those lines, leaving the
+separator and data rows unrendered (only the header shows, or the table renders
+empty/broken).
+Open this file: every table below should render fully — header, separator, and
+all data rows — with borders aligned. The blockquoted tables should look like
+the plain control table, just indented under the quote marker.
+### Control: table not in a blockquote
+| Name  | Role     |
+|-------|----------|
+| Alice | Engineer |
+| Bob   | Designer |
+### Table inside a blockquote
+> Some quoted intro text.
+>
+> | Name  | Role     |
+> |-------|----------|
+> | Alice | Engineer |
+> | Bob   | Designer |
+>
+> Trailing quoted text after the table.
+### Table inside a nested blockquote
+> Outer quote.
+>
+> > | Key   | Value |
+> > |-------|-------|
+> > | alpha | 1     |
+> > | beta  | 2     |
+### Blockquote table with alignment markers
+> | Left | Center | Right |
+> |:-----|:------:|------:|
+> | a    | b      | c     |
+> | dd   | ee     | ff    |


### PR DESCRIPTION
`get_node_text()` only applies a tree-sitter node's `col_start` offset to its *first* line. For a table nested inside a blockquote, lines 2+ therefore retain the `> ` block-continuation prefix, and the lpeg row parser in `parsers/markdown.lua` fails silently on them — leaving the separator and data rows unparsed. Symptoms: no alignment is detected, and the separator row leaks into the data-row count, so blockquoted tables render broken/empty.
                                                                                                                                                                                                                                                                                                                                                                                                                                                               
The fix strips `range.col_start` characters from lines after the first, and skips empty/blank lines (e.g. trailing `>` markers).
                                                                                                                                                                                                                                                                                                                                                                                                                                                               
A fixture (`test/blockquote_table.md`) is included covering a plain control table, a simple blockquote table, a nested blockquote table, and a blockquote table with alignment markers.
