### PR TITLE
feat(latex, symbols): add missing LaTeX2e/amsmath/amssymb commands and \mathscr font

### DIFF
--- a/doc/markview.nvim-latex.txt
+++ b/doc/markview.nvim-latex.txt
@@ -82,61 +82,61 @@ Demo {img:2}
 	---@param cmd_hl? string Highlight group for the command.
 	---@return markview.config.latex.commands.opts
 	local operator = function (name, text_pos, cmd_conceal, cmd_hl)
-		return {
-			condition = function (item)
-				return #item.args == 1;
-			end,
+	    return {
+	        condition = function (item)
+	            return #item.args == 1;
+	        end,
 	
-			on_command = function (item)
-				local symbols = require("markview.symbols");
+	        on_command = function (item)
+	            local symbols = require("markview.symbols");
 	
-				return {
-					end_col = item.range[2] + (cmd_conceal or 1),
-					conceal = "",
+	            return {
+	                end_col = item.range[2] + (cmd_conceal or 1),
+	                conceal = "",
 	
-					virt_text_pos = text_pos or "overlay",
-					virt_text = {
-						{ symbols.tostring("default", name), cmd_hl or "@keyword.function" }
-					},
+	                virt_text_pos = text_pos or "overlay",
+	                virt_text = {
+	                    { symbols.tostring("default", name), cmd_hl or "@keyword.function" }
+	                },
 	
-					hl_mode = "combine"
-				}
-			end,
+	                hl_mode = "combine"
+	            }
+	        end,
 	
-			on_args = {
-				{
-					on_before = function (item)
-						return {
-							end_col = item.range[2] + 1,
+	        on_args = {
+	            {
+	                on_before = function (item)
+	                    return {
+	                        end_col = item.range[2] + 1,
 	
-							virt_text_pos = "overlay",
-							virt_text = {
-								{ "(", "@punctuation.bracket" }
-							},
+	                        virt_text_pos = "overlay",
+	                        virt_text = {
+	                            { "(", "@punctuation.bracket" }
+	                        },
 	
-							hl_mode = "combine"
-						}
-					end,
+	                        hl_mode = "combine"
+	                    }
+	                end,
 	
-					after_offset = function (range)
-						return { range[1], range[2], range[3], range[4] - 1 };
-					end,
+	                after_offset = function (range)
+	                    return { range[1], range[2], range[3], range[4] - 1 };
+	                end,
 	
-					on_after = function (item)
-						return {
-							end_col = item.range[4],
+	                on_after = function (item)
+	                    return {
+	                        end_col = item.range[4],
 	
-							virt_text_pos = "overlay",
-							virt_text = {
-								{ ")", "@punctuation.bracket" }
-							},
+	                        virt_text_pos = "overlay",
+	                        virt_text = {
+	                            { ")", "@punctuation.bracket" }
+	                        },
 	
-							hl_mode = "combine"
-						}
-					end
-				}
-			}
-		};
+	                        hl_mode = "combine"
+	                    }
+	                end
+	            }
+	        }
+	    };
 	end
 	
 	commands = {
@@ -428,6 +428,7 @@ Demo {img:3}
 	    mathbf = { enable = true },
 	    mathbfit = { enable = true },
 	    mathcal = { enable = true },
+	    mathscr = { enable = true },
 	    mathbfscr = { enable = true },
 	    mathfrak = { enable = true },
 	    mathbb = { enable = true },

--- a/lua/markview/config/latex.lua
+++ b/lua/markview/config/latex.lua
@@ -318,6 +318,7 @@ return {
 		mathbf = { enable = true },
 		mathbfit = { enable = true },
 		mathcal = { enable = true },
+		mathscr = { enable = true },
 		mathbfscr = { enable = true },
 		mathfrak = { enable = true },
 		mathbb = { enable = true },

--- a/lua/markview/symbols.lua
+++ b/lua/markview/symbols.lua
@@ -4299,6 +4299,37 @@ symbols.entries = {
 	["ggcurly"] = "⪼",
 	["Top"] = "⫪",
 	["Bot"] = "⫫",
+
+	-- LaTeX2e/amsmath/amssymb commands without a unicode-math name.
+	["bigcirc"] = "○",
+	["circlearrowleft"] = "↺",
+	["circlearrowright"] = "↻",
+	["circledS"] = "Ⓢ",
+	["dotsb"] = "⋯",
+	["dotsc"] = "…",
+	["dotsi"] = "⋯",
+	["dotsm"] = "⋯",
+	["dotso"] = "…",
+	["emptyset"] = "∅",
+	["enspace"] = " ",
+	["gvertneqq"] = "≩︀",
+	["hbar"] = "ħ",
+	["iff"] = "⟺",
+	["impliedby"] = "⟸",
+	["implies"] = "⟹",
+	["land"] = "∧",
+	["ldots"] = "…",
+	["lor"] = "∨",
+	["lvertneqq"] = "≨︀",
+	["nleqslant"] = "⩽̸",
+	["nsubseteqq"] = "⫅̸",
+	["nsupseteqq"] = "⫆̸",
+	["qquad"] = "  ",
+	["quad"] = " ",
+	["thickspace"] = " ",
+	["thinspace"] = " ",
+	["varsubsetneqq"] = "⊊︀",
+	["varsupsetneq"] = "⊋︀",
 };
 
 --- Maps typst symbol names to the symbol.
@@ -6324,6 +6355,10 @@ symbols.fonts = {
 		["9"] = "𝟗"
 	}
 }
+
+-- Unicode has a single script alphabet; `\mathscr` & `\mathcal`
+-- use the same characters.
+symbols.fonts.mathscr = symbols.fonts.mathcal;
 
 ---@param font string
 ---@param text string

--- a/test/latex.md
+++ b/test/latex.md
@@ -31,6 +31,7 @@ Hello LaTeX!
 \mathbffrak{Hello LaTeX!}
 \mathbb{Hello LaTeX!}
 \mathbfscr{Hello LaTeX!}
+\mathscr{Hello LaTeX!}
 \mathrm{Hello LaTeX!}
 $$
 


### PR DESCRIPTION
## Problem

A number of very common LaTeX commands don't render because they have no entry in `symbols.entries`: the table covers unicode-math names, but not commands that unicode-math spells differently or omits entirely. Related: #178, #176.

Examples that currently render as raw text: `\ldots`, `\iff`, `\implies`, `\land`, `\lor`, `\emptyset`, `\mathscr{F}`.

## Changes

**`symbols.entries`**: 29 new entries, kept deliberately to the clearly-standard set (LaTeX2e core, amsmath, amssymb):

- `\ldots` and the amsmath dots family (`\dotsb`, `\dotsc`, `\dotsi`, `\dotsm`, `\dotso`)
- `\iff`, `\implies`, `\impliedby`, `\land`, `\lor`, `\emptyset`, `\hbar`, `\bigcirc`
- amssymb: `\circledS`, `\circlearrowleft`, `\circlearrowright`, `\gvertneqq`, `\lvertneqq`, `\nleqslant`, `\nsubseteqq`, `\nsupseteqq`, `\varsubsetneqq`, `\varsupsetneq`
- spacing: `\quad`, `\qquad`, `\enspace`, `\thinspace`, `\thickspace` mapped to the corresponding unicode space characters (U+2003 etc.)

**`symbols.fonts`**: new `mathscr` table, identical to `mathcal` since Unicode has a single script alphabet (both map to the U+1D49C block plus the Letterlike Symbols exceptions). The existing `#lua-match? "^\\math"` query already captures it, so only the symbol table, config default, docs and `test/latex.md` needed touching.

## Notes

- Glyph values were cross-checked against Julia's REPL latex-to-unicode table (`stdlib/REPL/src/latex_symbols.jl`, MIT), which is itself derived from W3C's `unicode.xml`. No code was taken from it, only the factual command-to-codepoint mapping.
- The spacing commands are the one opinionated part: they conceal to literal spaces, which felt more useful than leaving `\qquad` as raw text. Happy to drop them from the PR if you'd rather keep spacing commands unhandled.
- Argument-taking accents (`\hat`, `\vec`, `\ddot`, ...) were deliberately left out; concealing them to combining characters without reordering would render incorrectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)